### PR TITLE
Environment preparation for module testing

### DIFF
--- a/.github/workflows/modules-tests.yml
+++ b/.github/workflows/modules-tests.yml
@@ -27,7 +27,9 @@ jobs:
         run: pip3 install 'avocado-framework<104.0'
 
       - name: Include autils directory from source tree into Python's PATH
-        run: pip3 install .
+        run: |
+          pip install --upgrade pip
+          pip3 install .
 
       - name: run static checks
         uses: avocado-framework/avocado-ci-tools@main

--- a/tests/containerfiles/redhat_based
+++ b/tests/containerfiles/redhat_based
@@ -1,0 +1,5 @@
+FROM centos:stream9
+WORKDIR /home/autils
+COPY ./ ./
+RUN dnf install -y git
+RUN python3 -m ensurepip && python3 -m pip install .

--- a/tests/modules/archive/ar.py
+++ b/tests/modules/archive/ar.py
@@ -1,11 +1,6 @@
-try:
-    from autils.archive import ar
-except ImportError:
-    # FIXME: this should come instead from autils.  This is a
-    # workaround while the test framework does not know how
-    # to send the libraries themselves to the test environment
-    from avocado.utils import ar
 from avocado import Test
+
+from autils.archive import ar
 
 
 class Ar(Test):

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,25 +1,43 @@
 #!/usr/bin/env python3
 
+import asyncio
+import os
 import sys
 
 import yaml
 from avocado.core.job import Job
 from avocado.core.suite import TestSuite
+from avocado.utils.podman import Podman
 
 CONTAINER_IMAGE_MAPPING = {
-    "CentOS Stream 9": "centos:stream9",
-    "Fedora 36": "fedora:36",
-    "Fedora 37": "fedora:37",
+    "CentOS Stream 9": ("redhat_based", "centos:stream9"),
+    "Fedora 36": ("redhat_based", "fedora:36"),
+    "Fedora 37": ("redhat_based", "fedora:37"),
 }
 
 METADATA_PATH = sys.argv[1]
 with open(METADATA_PATH, "rb") as m:
     metadata = yaml.load(m, Loader=yaml.SafeLoader)
 
+images = []
 test_suites = []
 for platform in metadata["supported_platforms"]:
     name = platform.replace(" ", "_")
-    image = CONTAINER_IMAGE_MAPPING.get(platform)
+    containerfile, image_version = CONTAINER_IMAGE_MAPPING.get(platform)
+    loop = asyncio.get_event_loop()
+    _, result, _ = loop.run_until_complete(
+        Podman().execute(
+            "build",
+            "--no-cache",
+            "--from",
+            image_version,
+            "-f",
+            os.path.join("tests", "containerfiles", containerfile),
+            ".",
+        )
+    )
+    image = result.splitlines()[-1].decode()
+    images.append(image)
     config = {"run.spawner": "podman", "spawner.podman.image": image}
 
     config["resolver.references"] = metadata["tests"]
@@ -27,4 +45,7 @@ for platform in metadata["supported_platforms"]:
 
 
 with Job(test_suites=test_suites) as j:
-    sys.exit(j.run())
+    rc = j.run()
+    for image in images:
+        loop.run_until_complete(Podman().execute("image", "rm", "-f", image))
+    sys.exit(rc)


### PR DESCRIPTION
This change uses containerfile for building container images with the local changes of autils for testing. This approach will help us to use containers for running selftests in different environments.

Since autils uses only redhat based containers, we use on container file for removing duplicities and the actual system version is imported during the runtime. This solution supports multiple containerfiles in case that we will add different types of systems.

The build procedure uses the `--no-cache` flag to ensure that we always test the latest changes. As a downside to this is that the images needs to be always built which increases the test runtime.