### PR TITLE
Name change from Autils to AAutils

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# autils
+# AAutils
 Utility Libraries to power your tests (or general applications)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=64", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "autils"
+name = "aautils"
 dynamic = ["version"]
 requires-python = ">=3.7"
 authors = [
@@ -29,7 +29,7 @@ classifiers = [
 ]
 [project.urls]
 Homepage = "https://avocado-framework.github.io/autils.html"
-Repository = "https://github.com/avocado-framework/autils"
+Repository = "https://github.com/avocado-framework/aautils"
 
 [tool.setuptools]
 packages = ["autils"]


### PR DESCRIPTION
This change is needed, because the name Autils is already taken in PyPi, and we have picked the new name called AAutils. It still uses the name which has been picked by the community, and it can be used in our slogan `Utility Libraries to POWER your tests`.