### PR TITLE
Dynamic versioning - remove local version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,5 @@ Repository = "https://github.com/avocado-framework/aautils"
 packages = ["autils"]
 
 [tool.setuptools_scm]
+version_scheme = "guess-next-dev"
+local_scheme = "no-local-version"


### PR DESCRIPTION
Current dynamic versioning configuration uses latest local git commit has to generate local version of aautils. This causes troubles in pre-release testing because such version in not compatible with PEP 643 and can't be uploaded to test.pypi. This commit removes the commit hash from version and adds dev tag if the build is not part of the release process.

Reference:
https://github.com/avocado-framework/aautils/actions/runs/12123321653/job/33799201398#step:3:164