### PR TITLE
Code coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+source = autils/
+data_file = /tmp/autils_coverage/.coverage
+relative_files = True

--- a/.github/workflows/modules-tests.yml
+++ b/.github/workflows/modules-tests.yml
@@ -12,10 +12,15 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Avocado to run tests
-        run: pip3 install 'avocado-framework'
+        run: pip3 install 'avocado-framework' coverage
 
       - name: Run the ar module test
-        run: ./tests/test_module.py metadata/archive/ar.yml
+        run: ./tests/test_module.py metadata/archive/ar.yml --coverage
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   static-checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/modules-tests.yml
+++ b/.github/workflows/modules-tests.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Avocado to run tests
-        run: pip3 install 'avocado-framework<104.0'
+        run: pip3 install 'avocado-framework'
 
       - name: Run the ar module test
         run: ./tests/test_module.py metadata/archive/ar.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Avocado to allow for lint check on Python code under tests directory
-        run: pip3 install 'avocado-framework<104.0'
+        run: pip3 install 'avocado-framework'
 
       - name: Include autils directory from source tree into Python's PATH
         run: |
@@ -56,7 +56,7 @@ jobs:
 
       - name: Install Avocado to run tests
         if: steps.test_changes.outcome == 'failure'
-        run: pip3 install 'avocado-framework<104.0'
+        run: pip3 install 'avocado-framework'
 
       - name: Run API stability tests
         if: steps.test_changes.outcome == 'failure'

--- a/tests/containerfiles/redhat_based
+++ b/tests/containerfiles/redhat_based
@@ -3,3 +3,4 @@ WORKDIR /home/autils
 COPY ./ ./
 RUN dnf install -y git
 RUN python3 -m ensurepip && python3 -m pip install .
+RUN python3 -m pip install coverage


### PR DESCRIPTION
This PR adds possibility to run test_moduel.py with --coverage
argument, which will create print the coverage results to console and
create coverag.xml file. And it enables the codecov in CI

Reference: https://github.com/avocado-framework/aautils/issues/24
Signed-off-by: Jan Richter <jarichte@redhat.com>