### PR TITLE
Introduction of aurl utility

### DIFF
--- a/autils/aurl.py
+++ b/autils/aurl.py
@@ -1,0 +1,36 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2013-2014
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
+"""
+URL related functions.
+
+The strange name is to avoid accidental naming collisions in code.
+"""
+
+import urllib.parse
+
+#: The most common schemes (protocols) used in URLs
+COMMON_SCHEMES = ("http", "https", "ftp", "git")
+
+
+def is_url(path):
+    """Return `True` if path looks like an URL of common protocols.
+
+    Refer to :data:`COMMON_SCHEMES` for the list of common protocols.
+
+    :param path: path to check.
+    :rtype: Boolean.
+    """
+    url_parts = urllib.parse.urlparse(path)
+    return url_parts[0] in COMMON_SCHEMES

--- a/metadata/aurl.yml
+++ b/metadata/aurl.yml
@@ -1,0 +1,16 @@
+name: aurl
+description: URL related functions
+categories:
+  - Network
+  - Files
+maintainers:
+  - name: Jan Richter
+    email: jarichte@redhat.com
+    github_usr_name: richtja
+supported_platforms:
+  - CentOS Stream 9
+  - Fedora 36
+  - Fedora 37
+tests:
+  - tests/modules/aurl.py
+remote: false

--- a/tests/modules/aurl.py
+++ b/tests/modules/aurl.py
@@ -1,0 +1,31 @@
+import unittest
+
+from autils import aurl
+
+
+class TestAUrl(unittest.TestCase):
+    def test_valid_urls(self):
+        valid_urls = [
+            "http://www.example.com",
+            "https://www.example.com/path",
+            "ftp://ftp.example.com",
+            "git://github.com/user/repo.git",
+        ]
+        for url in valid_urls:
+            self.assertTrue(aurl.is_url(url), f"Expected {url} to be a valid URL")
+
+        invalid_urls = [
+            "www.example.com",
+            "htt://example",
+            "file:///path/to/file",
+        ]
+        for url in invalid_urls:
+            self.assertFalse(aurl.is_url(url), f"Expected {url} to be an invalid URL")
+
+        non_urls = [
+            "/path/to/file",
+            "not a url",
+            "",
+        ]
+        for path in non_urls:
+            self.assertFalse(aurl.is_url(path), f"Expected {path} to not be a URL")


### PR DESCRIPTION
This is a migration of aurl utility from avocado.utils.aurl to AAutils.

Reference: #39,
https://github.com/avocado-framework/avocado/blob/master/avocado/utils/aurl.py