### PR TITLE
docs: fix Read the Docs build configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,9 +19,7 @@ sphinx:
 # declare the Python requirements required to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
-   install:
-   - requirements: requirements-doc.txt
-   - method: pip
-   - path: .
-        
-
+  install:
+    - requirements: requirements-doc.txt
+    - method: pip
+      path: .

--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -9,4 +9,4 @@ Data Structures
 
 Path
 ====
-.. automodule:: autils.path
+.. automodule:: autils.file.path


### PR DESCRIPTION
This is an update for readthedocs python configuration to fix build isssues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Corrected YAML configuration formatting for documentation builds to ensure proper installation of Python dependencies.
  * Updated documentation references to reflect module restructuring for clearer navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->