### PR TITLE
Utils / gdb: remove duplicate docstring line

### DIFF
--- a/autils/devel/gdb.py
+++ b/autils/devel/gdb.py
@@ -839,7 +839,6 @@ class GDBRemote:
         :param expected_response: the (optional) response that is expected
                                   as a response for the command sent
         :type expected_response: str
-        :raises: RetransmissionRequestedError, UnexpectedResponseError
         :returns: raw data read from from the remote server
         :rtype: str
         :raises NotConnectedError: if the socket is not initialized


### PR DESCRIPTION
Reference: https://github.com/avocado-framework/avocado/pull/6253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation to reflect current method behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->