### PR TITLE
hypervisor/qemu: Qemu Utility Migration to AAutils

### DIFF
--- a/autils/hypervisor/qemu.py
+++ b/autils/hypervisor/qemu.py
@@ -1,0 +1,78 @@
+#
+# Library for qemu option related helper functions
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat (c) 2024 and Avocado contributors
+# Author: Yongxue Hong <yhong@redhat.com>
+
+"""QEMU hypervisor option related helper functions.
+
+This module provides utility functions for working with QEMU/KVM hypervisor
+options and capabilities, including checking for supported command-line options
+and retrieving available machine types.
+"""
+import re
+
+from autils.devel import process
+
+
+def has_option(option, qemu_path="/usr/bin/qemu-kvm"):
+    """Check if QEMU supports a specific command line option.
+
+    This function queries the QEMU help output to determine if a specific
+    command line option is supported by the given QEMU binary.
+
+    :param option: Command line option to check (without leading dash).
+    :type option: str
+    :param qemu_path: Path to the QEMU binary to check.
+    :type qemu_path: str
+    :return: True if the option is supported, False otherwise.
+    :rtype: bool
+    """
+    hlp = process.run(
+        f"{qemu_path} -help", shell=True, ignore_status=True, verbose=False
+    ).stdout_text
+    return bool(re.search(rf"^-{option}(\s|$)", hlp, re.MULTILINE))
+
+
+def get_support_machine_type(qemu_binary="/usr/libexec/qemu-kvm", remove_alias=False):
+    """Get machine types supported by the QEMU binary.
+
+    This function queries the QEMU binary for available machine types and
+    parses the output to return organized lists of machine names, descriptions,
+    and aliases.
+
+    :param qemu_binary: Path to the QEMU binary to query.
+    :type qemu_binary: str
+    :param remove_alias: If True, exclude alias information from results.
+    :type remove_alias: bool
+    :return: A tuple containing three lists: (machine_names, machine_types, machine_aliases).
+             Each list contains strings corresponding to the machine name, description,
+             and alias information respectively.
+    :rtype: tuple[list[str], list[str], list[str or None]]
+    """
+    o = process.run(f"{qemu_binary} -M ?").stdout_text.splitlines()
+    machine_name = []
+    machine_type = []
+    machine_alias = []
+    split_pattern = re.compile(
+        r"^(\S+)\s+(.*?)(?: (\((?:alias|default|deprecated).*))?$"
+    )
+    for item in o[1:]:
+        if "none" in item:
+            continue
+        machine_list = split_pattern.search(item).groups()
+        machine_name.append(machine_list[0])
+        machine_type.append(machine_list[1])
+        val = None if remove_alias else machine_list[2]
+        machine_alias.append(val)
+    return machine_name, machine_type, machine_alias

--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -16,6 +16,12 @@ Ports
 -----
 .. automodule:: autils.network.ports
 
+Hypervisor
+==========
+
+Qemu
+----
+.. automodule:: autils.hypervisor.qemu
 
 File
 =======

--- a/metadata/hypervisor/qemu.yml
+++ b/metadata/hypervisor/qemu.yml
@@ -1,0 +1,17 @@
+name: qemu
+description: Module for qemu option related helper functions
+
+categories:
+  - Virtualization
+maintainers:
+  - name: Yongxue Hong
+    email: yhong@redhat.com
+    github_usr_name: YongxueHong
+supported_platforms:
+  - CentOS Stream 9
+  - Fedora 36
+  - Fedora 37
+tests:
+  - tests/unit/modules/hypervisor/qemu.py
+  - tests/functional/modules/hypervisor/qemu.py
+remote: false

--- a/tests/functional/modules/hypervisor/qemu.py
+++ b/tests/functional/modules/hypervisor/qemu.py
@@ -1,0 +1,156 @@
+import os
+import subprocess
+import unittest
+
+from autils.hypervisor import qemu
+from tests.utils import skipOnLevelsInferiorThan
+
+
+class QemuFunctionalTest(unittest.TestCase):
+    """Functional tests for autils.hypervisor.qemu module"""
+
+    def setUp(self):
+        super().setUp()
+        self.available_qemu_paths = self._get_available_qemu_paths()
+
+    def _get_available_qemu_paths(self):
+        """Get the available qemu paths on the system"""
+        qemu_paths = [
+            "/usr/bin/qemu-kvm",
+            "/usr/bin/qemu-system-x86_64",
+            "/usr/libexec/qemu-kvm",
+            "/usr/bin/qemu",
+        ]
+
+        available_qemu_paths = []
+
+        for path in qemu_paths:
+            if os.path.exists(path):
+                try:
+                    result = subprocess.run(
+                        [path, "-help"], capture_output=True, timeout=10, check=False
+                    )
+                    if not result.returncode:
+                        available_qemu_paths.append(path)
+                except (subprocess.TimeoutExpired, FileNotFoundError):
+                    continue
+        return available_qemu_paths
+
+    @skipOnLevelsInferiorThan(2)
+    def test_has_option_with_real_qemu(self):
+        """Test has_option function with real QEMU binary"""
+        if not self.available_qemu_paths:
+            self.skipTest("QEMU not available on system")
+
+        default_qemu_path = "/usr/bin/qemu-kvm"
+        if default_qemu_path not in self.available_qemu_paths:
+            self.skipTest(
+                f"The default qemu path: {default_qemu_path} not available on system"
+            )
+
+        # Test common options that should exist in most QEMU versions
+        self.assertTrue(qemu.has_option("h"))
+        self.assertTrue(qemu.has_option("version"))
+
+        # Test option that should not exist
+        self.assertFalse(qemu.has_option("nonexistent-option-12345"))
+
+    @skipOnLevelsInferiorThan(2)
+    def test_has_option_with_custom_path(self):
+        """Test has_option with custom QEMU path"""
+        # Find an available QEMU binary
+        qemu_paths = [
+            "/usr/bin/qemu-system-x86_64",
+            "/usr/libexec/qemu-kvm",
+            "/usr/bin/qemu",
+        ]
+
+        available_path = None
+        for path in qemu_paths:
+            if os.path.exists(path):
+                available_path = path
+                break
+
+        if not available_path:
+            self.skipTest(
+                f"The custom qemu paths: {qemu_paths} not available on system"
+            )
+
+        if available_path:
+            result = qemu.has_option("h", available_path)
+            self.assertTrue(result)
+
+    @skipOnLevelsInferiorThan(2)
+    def test_get_support_machine_type_with_real_qemu(self):
+        """Test get_support_machine_type function with real QEMU binary"""
+        if not self.available_qemu_paths:
+            self.skipTest("QEMU not available on system")
+
+        names, types, aliases = qemu.get_support_machine_type(
+            self.available_qemu_paths[0]
+        )
+
+        # Verify return types
+        self.assertIsInstance(names, list)
+        self.assertIsInstance(types, list)
+        self.assertIsInstance(aliases, list)
+
+        # All lists should have the same length
+        self.assertEqual(len(names), len(types))
+        self.assertEqual(len(names), len(aliases))
+
+        # Should have at least one machine type
+        self.assertGreater(len(names), 0)
+
+        # Each name should be a string
+        for name in names:
+            self.assertIsInstance(name, str)
+            self.assertGreater(len(name), 0)
+
+        # Each type should be a string
+        for machine_type in types:
+            self.assertIsInstance(machine_type, str)
+
+        # Aliases can be None or strings
+        for alias in aliases:
+            self.assertTrue(alias is None or isinstance(alias, str))
+
+    @skipOnLevelsInferiorThan(2)
+    def test_get_support_machine_type_remove_alias(self):
+        """Test get_support_machine_type with remove_alias=True"""
+        if not self.available_qemu_paths:
+            self.skipTest("QEMU not available on system")
+
+        _, _, aliases = qemu.get_support_machine_type(
+            self.available_qemu_paths[0], remove_alias=True
+        )
+
+        # With remove_alias=True, all aliases should be None
+        for alias in aliases:
+            self.assertIsNone(alias)
+
+    @skipOnLevelsInferiorThan(2)
+    def test_get_support_machine_type_no_none_machines(self):
+        """Test that 'none' machines are filtered out"""
+        if not self.available_qemu_paths:
+            self.skipTest("QEMU not available on system")
+
+        names, _, _ = qemu.get_support_machine_type(self.available_qemu_paths[0])
+
+        # Should not contain 'none' in machine names
+        self.assertNotIn("none", names)
+
+    def test_has_option_invalid_qemu_path(self):
+        """Test has_option with invalid QEMU path"""
+        result = qemu.has_option("help", "/nonexistent/qemu/path")
+        # Should handle the error gracefully and return False
+        self.assertFalse(result)
+
+    def test_get_support_machine_type_invalid_path(self):
+        """Test get_support_machine_type with invalid QEMU path"""
+        with self.assertRaises((subprocess.CalledProcessError, FileNotFoundError)):
+            qemu.get_support_machine_type("/nonexistent/qemu/path")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/modules/hypervisor/qemu.py
+++ b/tests/unit/modules/hypervisor/qemu.py
@@ -1,0 +1,267 @@
+import unittest.mock
+
+from autils.hypervisor import qemu
+
+
+class HasOptionTest(unittest.TestCase):
+    @unittest.mock.patch("autils.devel.process.run")
+    def test_has_option_found(self, mock_process_run):
+        mock_cmd_result = unittest.mock.MagicMock()
+        mock_cmd_result.stdout_text = (
+            "-netdev    specify the network backend\n"
+            "-device    add device\n"
+            "-enable-kvm enable KVM acceleration\n"
+        )
+        mock_process_run.return_value = mock_cmd_result
+
+        result = qemu.has_option("netdev")
+
+        mock_process_run.assert_called_once_with(
+            "/usr/bin/qemu-kvm -help", shell=True, ignore_status=True, verbose=False
+        )
+        self.assertTrue(result)
+
+    @unittest.mock.patch("autils.devel.process.run")
+    def test_has_option_not_found(self, mock_process_run):
+        mock_cmd_result = unittest.mock.MagicMock()
+        mock_cmd_result.stdout_text = (
+            "-netdev    specify the network backend\n"
+            "-device    add device\n"
+            "-enable-kvm enable KVM acceleration\n"
+        )
+        mock_process_run.return_value = mock_cmd_result
+
+        result = qemu.has_option("nonexistent")
+
+        mock_process_run.assert_called_once_with(
+            "/usr/bin/qemu-kvm -help", shell=True, ignore_status=True, verbose=False
+        )
+        self.assertFalse(result)
+
+    @unittest.mock.patch("autils.devel.process.run")
+    def test_has_option_custom_qemu_path(self, mock_process_run):
+        mock_cmd_result = unittest.mock.MagicMock()
+        mock_cmd_result.stdout_text = "-enable-kvm enable KVM acceleration\n"
+        mock_process_run.return_value = mock_cmd_result
+
+        result = qemu.has_option("enable-kvm", "/custom/path/qemu")
+
+        mock_process_run.assert_called_once_with(
+            "/custom/path/qemu -help", shell=True, ignore_status=True, verbose=False
+        )
+        self.assertTrue(result)
+
+    @unittest.mock.patch("autils.devel.process.run")
+    def test_has_option_regex_match_beginning_of_line(self, mock_process_run):
+        mock_cmd_result = unittest.mock.MagicMock()
+        mock_cmd_result.stdout_text = (
+            "some text with enable-kvm in middle\n"
+            "-enable-kvm enable KVM acceleration\n"
+        )
+        mock_process_run.return_value = mock_cmd_result
+
+        result = qemu.has_option("enable-kvm")
+
+        mock_process_run.assert_called_once_with(
+            "/usr/bin/qemu-kvm -help", shell=True, ignore_status=True, verbose=False
+        )
+        self.assertTrue(result)
+
+    @unittest.mock.patch("autils.devel.process.run")
+    def test_has_option_regex_no_match_middle_of_line(self, mock_process_run):
+        mock_cmd_result = unittest.mock.MagicMock()
+        mock_cmd_result.stdout_text = (
+            "some text with enable-kvm in middle\nother line\n"
+        )
+        mock_process_run.return_value = mock_cmd_result
+
+        result = qemu.has_option("enable-kvm")
+        mock_process_run.assert_called_once_with(
+            "/usr/bin/qemu-kvm -help", shell=True, ignore_status=True, verbose=False
+        )
+        self.assertFalse(result)
+
+    @unittest.mock.patch("autils.devel.process.run")
+    def test_has_option_with_space_after(self, mock_process_run):
+        mock_cmd_result = unittest.mock.MagicMock()
+        mock_cmd_result.stdout_text = "-device TYPE[,PROP=VALUE,...]  add device\n"
+        mock_process_run.return_value = mock_cmd_result
+
+        result = qemu.has_option("device")
+        mock_process_run.assert_called_once_with(
+            "/usr/bin/qemu-kvm -help", shell=True, ignore_status=True, verbose=False
+        )
+        self.assertTrue(result)
+
+    @unittest.mock.patch("autils.devel.process.run")
+    def test_has_option_at_end_of_line(self, mock_process_run):
+        mock_cmd_result = unittest.mock.MagicMock()
+        mock_cmd_result.stdout_text = "-h\n-help\n"
+        mock_process_run.return_value = mock_cmd_result
+
+        result = qemu.has_option("h")
+
+        mock_process_run.assert_called_once_with(
+            "/usr/bin/qemu-kvm -help", shell=True, ignore_status=True, verbose=False
+        )
+        self.assertTrue(result)
+
+    @unittest.mock.patch("autils.devel.process.run")
+    def test_has_option_with_invalid_qemu_path(self, mock_process_run):
+        mock_cmd_result = unittest.mock.MagicMock()
+        mock_cmd_result.stdout_text = ""
+        mock_process_run.return_value = mock_cmd_result
+
+        result = qemu.has_option("help", "/custom/invalid_path/qemu")
+
+        mock_process_run.assert_called_once_with(
+            "/custom/invalid_path/qemu -help",
+            shell=True,
+            ignore_status=True,
+            verbose=False,
+        )
+        self.assertFalse(result)
+
+
+class GetSupportMachineTypeTest(unittest.TestCase):
+    @unittest.mock.patch("autils.devel.process.run")
+    def test_get_support_machine_type_basic(self, mock_process_run):
+        mock_cmd_result = unittest.mock.MagicMock()
+        mock_cmd_result.stdout_text = """Supported machines are:
+pc-i440fx-8.2       Standard PC (i440FX + PIIX, 1996) (alias of pc)
+pc-i440fx-8.1       Standard PC (i440FX + PIIX, 1996)
+pc-q35-8.2         Standard PC (Q35 + ICH9, 2009) (alias of q35) (default)
+none                empty machine
+"""
+        mock_process_run.return_value = mock_cmd_result
+
+        names, types, aliases = qemu.get_support_machine_type()
+
+        mock_process_run.assert_called_once_with("/usr/libexec/qemu-kvm -M ?")
+        self.assertEqual(names, ["pc-i440fx-8.2", "pc-i440fx-8.1", "pc-q35-8.2"])
+        self.assertEqual(
+            types,
+            [
+                "Standard PC (i440FX + PIIX, 1996)",
+                "Standard PC (i440FX + PIIX, 1996)",
+                "Standard PC (Q35 + ICH9, 2009)",
+            ],
+        )
+        self.assertEqual(aliases, ["(alias of pc)", None, "(alias of q35) (default)"])
+
+    @unittest.mock.patch("autils.devel.process.run")
+    def test_get_support_machine_type_custom_binary(self, mock_process_run):
+        mock_cmd_result = unittest.mock.MagicMock()
+        mock_cmd_result.stdout_text = """Supported machines are:
+pc-i440fx-8.2       Standard PC (i440FX + PIIX, 1996)
+"""
+        mock_process_run.return_value = mock_cmd_result
+
+        names, types, aliases = qemu.get_support_machine_type("/custom/qemu-binary")
+
+        mock_process_run.assert_called_once_with("/custom/qemu-binary -M ?")
+        self.assertEqual(names, ["pc-i440fx-8.2"])
+        self.assertEqual(types, ["Standard PC (i440FX + PIIX, 1996)"])
+        self.assertEqual(aliases, [None])
+
+    @unittest.mock.patch("autils.devel.process.run")
+    def test_get_support_machine_type_remove_alias(self, mock_process_run):
+        mock_cmd_result = unittest.mock.MagicMock()
+        mock_cmd_result.stdout_text = """Supported machines are:
+pc-i440fx-8.2       Standard PC (i440FX + PIIX, 1996) (alias of pc)
+pc-q35-8.2         Standard PC (Q35 + ICH9, 2009) (default)
+none                empty machine
+"""
+        mock_process_run.return_value = mock_cmd_result
+
+        names, types, aliases = qemu.get_support_machine_type(remove_alias=True)
+
+        mock_process_run.assert_called_once_with("/usr/libexec/qemu-kvm -M ?")
+
+        self.assertEqual(names, ["pc-i440fx-8.2", "pc-q35-8.2"])
+        self.assertEqual(
+            types,
+            ["Standard PC (i440FX + PIIX, 1996)", "Standard PC (Q35 + ICH9, 2009)"],
+        )
+        self.assertEqual(aliases, [None, None])
+
+    @unittest.mock.patch("autils.devel.process.run")
+    def test_get_support_machine_type_skip_none(self, mock_process_run):
+        mock_cmd_result = unittest.mock.MagicMock()
+        mock_cmd_result.stdout_text = """Supported machines are:
+pc-i440fx-8.2       Standard PC (i440FX + PIIX, 1996)
+none                empty machine
+pc-q35-8.2         Standard PC (Q35 + ICH9, 2009)
+"""
+        mock_process_run.return_value = mock_cmd_result
+
+        names, types, aliases = qemu.get_support_machine_type()
+
+        mock_process_run.assert_called_once_with("/usr/libexec/qemu-kvm -M ?")
+
+        self.assertEqual(names, ["pc-i440fx-8.2", "pc-q35-8.2"])
+        self.assertEqual(
+            types,
+            ["Standard PC (i440FX + PIIX, 1996)", "Standard PC (Q35 + ICH9, 2009)"],
+        )
+        self.assertEqual(aliases, [None, None])
+
+    @unittest.mock.patch("autils.devel.process.run")
+    def test_get_support_machine_type_with_deprecated(self, mock_process_run):
+        mock_cmd_result = unittest.mock.MagicMock()
+        mock_cmd_result.stdout_text = """Supported machines are:
+pc-i440fx-8.2       Standard PC (i440FX + PIIX, 1996)
+pc-i440fx-2.12      Standard PC (i440FX + PIIX, 1996) (deprecated)
+"""
+        mock_process_run.return_value = mock_cmd_result
+
+        names, types, aliases = qemu.get_support_machine_type()
+
+        mock_process_run.assert_called_once_with("/usr/libexec/qemu-kvm -M ?")
+
+        self.assertEqual(names, ["pc-i440fx-8.2", "pc-i440fx-2.12"])
+        self.assertEqual(
+            types,
+            ["Standard PC (i440FX + PIIX, 1996)", "Standard PC (i440FX + PIIX, 1996)"],
+        )
+        self.assertEqual(aliases, [None, "(deprecated)"])
+
+    @unittest.mock.patch("autils.devel.process.run")
+    def test_get_support_machine_type_complex_alias(self, mock_process_run):
+        mock_cmd_result = unittest.mock.MagicMock()
+        mock_cmd_result.stdout_text = """Supported machines are:
+pc-q35-8.2         Standard PC (Q35 + ICH9, 2009) (alias of q35) (default)
+microvm            microvm (i386)
+"""
+        mock_process_run.return_value = mock_cmd_result
+
+        names, types, aliases = qemu.get_support_machine_type()
+
+        mock_process_run.assert_called_once_with("/usr/libexec/qemu-kvm -M ?")
+
+        self.assertEqual(names, ["pc-q35-8.2", "microvm"])
+        self.assertEqual(types, ["Standard PC (Q35 + ICH9, 2009)", "microvm (i386)"])
+        self.assertEqual(aliases, ["(alias of q35) (default)", None])
+
+    @unittest.mock.patch("autils.devel.process.run")
+    def test_get_support_machine_type_return_types(self, mock_process_run):
+        mock_cmd_result = unittest.mock.MagicMock()
+        mock_cmd_result.stdout_text = """Supported machines are:
+pc-i440fx-8.2       Standard PC (i440FX + PIIX, 1996)
+"""
+        mock_process_run.return_value = mock_cmd_result
+
+        result = qemu.get_support_machine_type()
+
+        mock_process_run.assert_called_once_with("/usr/libexec/qemu-kvm -M ?")
+
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 3)
+        names, types, aliases = result
+        self.assertIsInstance(names, list)
+        self.assertIsInstance(types, list)
+        self.assertIsInstance(aliases, list)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add QEMU hypervisor utilities with two key functions:
- has_option(): Check if QEMU supports specific command line options
- get_support_machine_type(): Retrieve available QEMU machine types

Includes comprehensive unit and functional tests, documentation,
and metadata for the new qemu module.

Reference:
https://github.com/avocado-framework/avocado-vt/blob/master/virttest/vt_utils/qemu_utils.py
