### PR TITLE
Migrate genio module from avocado to autils

### DIFF
--- a/autils/file/genio.py
+++ b/autils/file/genio.py
@@ -1,0 +1,312 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# This code was inspired in the autotest project,
+# client/shared/utils.py
+# Authors: Martin J Bligh <mbligh@google.com>
+#          Andy Whitcroft <apw@shadowen.org>
+#
+# Modification History:
+# - Added read_line_with_matching_pattern()
+
+"""Generic IO related functions for file operations."""
+
+import logging
+import os
+import re
+
+from autils.file import crypto
+
+LOG = logging.getLogger(__name__)
+
+
+class GenIOError(Exception):
+    """Base Exception Class for all IO exceptions."""
+
+
+def ask(question, auto=False):
+    """Prompt the user with a (y/n) question.
+
+    :param question: Question to be asked.
+    :type question: str
+    :param auto: Whether to return "y" instead of asking the question.
+    :type auto: bool
+    :return: User answer.
+    :rtype: str
+
+    Example::
+
+        >>> ask("Do you want to continue?", auto=True)
+        'y'
+    """
+    if auto:
+        LOG.info("%s (y/n) y", question)
+        return "y"
+    return input(f"{question} (y/n) ")
+
+
+def read_file(filename):
+    """Read the entire contents of a file.
+
+    :param filename: Path to the file.
+    :type filename: str
+    :return: File contents.
+    :rtype: str
+    :raises FileNotFoundError: When the file does not exist.
+    :raises PermissionError: When the file cannot be read due to permissions.
+
+    Example::
+
+        >>> read_file("/etc/hostname")  # doctest: +SKIP
+        'myhost\\n'
+    """
+    with open(filename, "r", encoding="utf-8") as file_obj:
+        contents = file_obj.read()
+    return contents
+
+
+def read_one_line(filename):
+    """Read the first line of a file.
+
+    The returned line has the trailing newline character stripped.
+
+    :param filename: Path to the file.
+    :type filename: str
+    :return: First line contents with newline stripped.
+    :rtype: str
+    :raises FileNotFoundError: When the file does not exist.
+    :raises PermissionError: When the file cannot be read due to permissions.
+
+    Example::
+
+        >>> read_one_line("/etc/hostname")  # doctest: +SKIP
+        'myhost'
+    """
+    with open(filename, "r", encoding="utf-8") as file_obj:
+        line = file_obj.readline().rstrip("\n")
+    return line
+
+
+def read_all_lines(filename):
+    """Return all lines of a given file.
+
+    This utility method returns an empty list in any error scenario,
+    that is, it doesn't attempt to identify error paths and raise
+    appropriate exceptions. It does exactly the opposite to that.
+
+    This should be used when it's fine or desirable to have an empty
+    set of lines if a file is missing or is unreadable.
+
+    :param filename: Path to the file.
+    :type filename: str
+    :return: All lines of the file as a list with newlines stripped.
+    :rtype: list
+
+    Example::
+
+        >>> read_all_lines("/etc/hosts")  # doctest: +SKIP
+        ['127.0.0.1 localhost', '::1 localhost']
+        >>> read_all_lines("/nonexistent/file.txt")
+        []
+    """
+    contents = []
+    try:
+        with open(filename, "r", encoding="utf-8") as file_obj:
+            contents = [line.rstrip("\n") for line in file_obj.readlines()]
+    except Exception:  # pylint: disable=W0703
+        pass
+    return contents
+
+
+def read_line_with_matching_pattern(filename, pattern):
+    """Return lines from a file that contain a given pattern.
+
+    This method returns all lines where the pattern substring is found.
+    The search uses simple substring matching (not regex).
+
+    :param filename: Path to the file to be read.
+    :type filename: str
+    :param pattern: Pattern substring to search for in each line.
+    :type pattern: str
+    :return: All lines from the file that contain the pattern, with newlines stripped.
+    :rtype: list
+    :raises FileNotFoundError: When the file does not exist.
+    :raises PermissionError: When the file cannot be read due to permissions.
+
+    Example::
+
+        >>> read_line_with_matching_pattern("/etc/passwd", "root")  # doctest: +SKIP
+        ['root:x:0:0:root:/root:/bin/bash']
+    """
+    contents = []
+    with open(filename, "r", encoding="utf-8") as file_obj:
+        for line in file_obj.readlines():
+            if pattern in line:
+                contents.append(line.rstrip("\n"))
+    return contents
+
+
+def write_file(filename, data):
+    """Write data to a file.
+
+    This will overwrite any existing content in the file. If the file
+    does not exist, it will be created.
+
+    :param filename: Path to the file.
+    :type filename: str
+    :param data: Data to be written to the file.
+    :type data: str
+    :raises FileNotFoundError: When the parent directory does not exist.
+    :raises PermissionError: When the file cannot be written due to permissions.
+
+    Example::
+
+        >>> write_file("/tmp/test.txt", "Hello World")  # doctest: +SKIP
+    """
+    with open(filename, "w", encoding="utf-8") as file_obj:
+        file_obj.write(data)
+
+
+def write_one_line(filename, line):
+    """Write one line of text to a file.
+
+    A newline character is automatically appended. Any existing trailing
+    newline in the input line is stripped before adding the newline.
+
+    :param filename: Path to the file.
+    :type filename: str
+    :param line: Line to be written.
+    :type line: str
+    :raises FileNotFoundError: When the parent directory does not exist.
+    :raises PermissionError: When the file cannot be written due to permissions.
+
+    Example::
+
+        >>> write_one_line("/tmp/test.txt", "Hello World")  # doctest: +SKIP
+    """
+    write_file(filename, line.rstrip("\n") + "\n")
+
+
+def write_file_or_fail(filename, data):
+    """Write to a file and raise GenIOError on write failure.
+
+    Unlike :func:`write_file`, this function catches OSError exceptions
+    and re-raises them as GenIOError with a descriptive message.
+
+    :param filename: Path to the file.
+    :type filename: str
+    :param data: Data to be written to the file.
+    :type data: str
+    :raises GenIOError: When the write operation fails for any reason.
+
+    Example::
+
+        >>> write_file_or_fail("/tmp/test.txt", "Hello World")  # doctest: +SKIP
+    """
+    try:
+        with open(filename, "w", encoding="utf-8") as file_obj:
+            file_obj.write(data)
+    except OSError as details:
+        raise GenIOError(f"The write to {filename} failed: {details}") from details
+
+
+def append_file(filename, data):
+    """Append data to a file.
+
+    If the file does not exist, it will be created.
+
+    :param filename: Path to the file.
+    :type filename: str
+    :param data: Data to be appended to the file.
+    :type data: str
+    :raises FileNotFoundError: When the parent directory does not exist.
+    :raises PermissionError: When the file cannot be written due to permissions.
+
+    Example::
+
+        >>> append_file("/tmp/log.txt", "New log entry\\n")  # doctest: +SKIP
+    """
+    with open(filename, "a+", encoding="utf-8") as file_obj:
+        file_obj.write(data)
+
+
+def append_one_line(filename, line):
+    """Append one line of text to a file.
+
+    A newline character is automatically appended. Any existing trailing
+    newline in the input line is stripped before adding the newline.
+    If the file does not exist, it will be created.
+
+    :param filename: Path to the file.
+    :type filename: str
+    :param line: Line to be appended.
+    :type line: str
+    :raises FileNotFoundError: When the parent directory does not exist.
+    :raises PermissionError: When the file cannot be written due to permissions.
+
+    Example::
+
+        >>> append_one_line("/tmp/log.txt", "Log entry 1")  # doctest: +SKIP
+        >>> append_one_line("/tmp/log.txt", "Log entry 2")  # doctest: +SKIP
+    """
+    append_file(filename, line.rstrip("\n") + "\n")
+
+
+def is_pattern_in_file(filename, pattern):
+    """Check if a regex pattern matches anywhere in a file.
+
+    The pattern is matched using Python's re.search with MULTILINE mode,
+    allowing patterns like ``^`` and ``$`` to match at line boundaries.
+
+    :param filename: Path to the file.
+    :type filename: str
+    :param pattern: Regular expression pattern to search for.
+    :type pattern: str
+    :return: True if pattern matches anywhere in the file, False otherwise.
+    :rtype: bool
+    :raises GenIOError: When filename is not a regular file (e.g., directory).
+
+    Example::
+
+        >>> is_pattern_in_file("/etc/passwd", r"^root:")  # doctest: +SKIP
+        True
+        >>> is_pattern_in_file("/etc/passwd", r"nonexistent")  # doctest: +SKIP
+        False
+    """
+    if not os.path.isfile(filename):
+        raise GenIOError(f"invalid file {filename} " f"to match pattern {pattern}")
+    with open(filename, "r", encoding="utf-8") as content_file:
+        if re.search(pattern, content_file.read(), re.MULTILINE):
+            return True
+    return False
+
+
+def are_files_equal(filename, other):
+    """Compare two files for equality using cryptographic hashing.
+
+    This function computes the hash of both files and compares them,
+    which is efficient for large files. Files are considered equal
+    if they have identical content.
+
+    :param filename: Path to the first file.
+    :type filename: str
+    :param other: Path to the second file.
+    :type other: str
+    :return: True if files have identical content, False otherwise.
+    :rtype: bool
+
+    Example::
+
+        >>> are_files_equal("/tmp/file1.txt", "/tmp/file2.txt")  # doctest: +SKIP
+        True
+    """
+    hash_1 = crypto.hash_file(filename)
+    hash_2 = crypto.hash_file(other)
+    return hash_1 == hash_2

--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -24,6 +24,10 @@ Crypto
 ------
 .. automodule:: autils.file.crypto
 
+Genio
+-----
+.. automodule:: autils.file.genio
+
 Path
 ----
 .. automodule:: autils.file.path

--- a/metadata/file/genio.yml
+++ b/metadata/file/genio.yml
@@ -1,0 +1,18 @@
+name: genio
+description: Generic IO module for file read/write operations.
+
+categories:
+  - Files
+  - IO
+maintainers:
+  - name: Harvey James Lynden
+    email: hlynden@redhat.com
+    github_usr_name: harvey0100
+supported_platforms:
+  - CentOS Stream 9
+  - Fedora 36
+  - Fedora 37
+tests:
+  - tests/unit/modules/file/genio.py
+  - tests/functional/modules/file/genio.py
+remote: false

--- a/tests/functional/modules/file/genio.py
+++ b/tests/functional/modules/file/genio.py
@@ -1,0 +1,200 @@
+"""Functional tests for the genio module.
+
+These tests validate the genio module in real-world file system scenarios,
+including cross-module interactions and integration patterns.
+"""
+
+import os
+import unittest
+
+from autils.file import genio
+from tests.utils import TestCaseTmpDir
+
+
+class TestGenioFileOperations(TestCaseTmpDir):
+    """Functional tests for genio file read/write operations."""
+
+    def test_write_read_roundtrip(self):
+        """Test writing and reading back produces identical content."""
+        test_file = os.path.join(self.tmpdir.name, "roundtrip.txt")
+        original_content = "Line 1\nLine 2\nLine 3\n"
+        genio.write_file(test_file, original_content)
+        read_content = genio.read_file(test_file)
+        self.assertEqual(read_content, original_content)
+
+    def test_write_one_line_read_one_line_roundtrip(self):
+        """Test write_one_line and read_one_line roundtrip."""
+        test_file = os.path.join(self.tmpdir.name, "one_line.txt")
+        genio.write_one_line(test_file, "Single line content")
+        line = genio.read_one_line(test_file)
+        self.assertEqual(line, "Single line content")
+
+    def test_append_builds_file_incrementally(self):
+        """Test building a file incrementally with append operations."""
+        test_file = os.path.join(self.tmpdir.name, "incremental.txt")
+        lines_to_add = ["First line", "Second line", "Third line"]
+        for line in lines_to_add:
+            genio.append_one_line(test_file, line)
+        result_lines = genio.read_all_lines(test_file)
+        self.assertEqual(result_lines, lines_to_add)
+
+    def test_large_file_operations(self):
+        """Test operations on larger files."""
+        test_file = os.path.join(self.tmpdir.name, "large.txt")
+        lines = [f"Line {i}: {'x' * 80}" for i in range(1000)]
+        content = "\n".join(lines)
+        genio.write_file(test_file, content)
+        read_content = genio.read_file(test_file)
+        self.assertEqual(read_content, content)
+
+    def test_unicode_file_operations(self):
+        """Test file operations with unicode content."""
+        test_file = os.path.join(self.tmpdir.name, "unicode.txt")
+        unicode_content = "日本語テスト\nПривет мир\n🎉 Emoji test 🚀\n"
+        genio.write_file(test_file, unicode_content)
+        read_content = genio.read_file(test_file)
+        self.assertEqual(read_content, unicode_content)
+
+    def test_special_characters_in_content(self):
+        """Test file operations with special characters."""
+        test_file = os.path.join(self.tmpdir.name, "special.txt")
+        special_content = "Tab:\tNewline:\\n\nBackslash:\\\nQuotes:\"'`\n"
+        genio.write_file(test_file, special_content)
+        read_content = genio.read_file(test_file)
+        self.assertEqual(read_content, special_content)
+
+
+class TestGenioPatternMatching(TestCaseTmpDir):
+    """Functional tests for genio pattern matching operations."""
+
+    def setUp(self):
+        super().setUp()
+        self.log_file = os.path.join(self.tmpdir.name, "debug.log")
+        log_content = (
+            "2024-01-01 10:00:00,123 autils.test test_module      L0042 INFO | Starting test\n"
+            "2024-01-01 10:00:01,456 autils.test test_module      L0043 DEBUG| Loading configuration\n"
+            "2024-01-01 10:00:02,789 autils.test test_module      L0044 ERROR| Failed to connect to database\n"
+            "2024-01-01 10:00:03,012 autils.test test_module      L0045 INFO | Retrying connection\n"
+            "2024-01-01 10:00:04,345 autils.test test_module      L0046 ERROR| Connection timeout\n"
+            "2024-01-01 10:00:05,678 autils.test test_module      L0047 INFO | Connection established\n"
+        )
+        genio.write_file(self.log_file, log_content)
+
+    def test_log_analysis_workflow(self):
+        """Test analyzing a log file - finding errors and verifying patterns."""
+        # Find all error lines
+        error_lines = genio.read_line_with_matching_pattern(self.log_file, "ERROR")
+        self.assertEqual(len(error_lines), 2)
+        self.assertTrue(all("ERROR" in line for line in error_lines))
+
+        # Verify timestamp pattern exists
+        self.assertTrue(genio.is_pattern_in_file(self.log_file, r"\d{4}-\d{2}-\d{2}"))
+
+    def test_config_file_pattern_extraction(self):
+        """Test extracting values from a config-like file."""
+        config_file = os.path.join(self.tmpdir.name, "config.ini")
+        config_content = (
+            "[database]\n"
+            "host=localhost\n"
+            "port=5432\n"
+            "name=testdb\n"
+            "\n"
+            "[server]\n"
+            "host=0.0.0.0\n"
+            "port=8080\n"
+        )
+        genio.write_file(config_file, config_content)
+        # Find all host settings
+        host_lines = genio.read_line_with_matching_pattern(config_file, "host=")
+        self.assertEqual(len(host_lines), 2)
+        # Verify section markers
+        self.assertTrue(genio.is_pattern_in_file(config_file, r"\[database\]"))
+
+
+class TestGenioFileComparison(TestCaseTmpDir):
+    """Functional tests for genio file comparison in workflows."""
+
+    def test_copy_verification_workflow(self):
+        """Test using are_files_equal to verify file copy integrity."""
+        source = os.path.join(self.tmpdir.name, "source.txt")
+        dest = os.path.join(self.tmpdir.name, "dest.txt")
+        genio.write_file(source, "Original content for copy test\n")
+
+        # Simulate a copy by reading and writing
+        content = genio.read_file(source)
+        genio.write_file(dest, content)
+
+        # Verify copy integrity
+        self.assertTrue(genio.are_files_equal(source, dest))
+
+        # Modify dest and verify they're now different
+        genio.append_file(dest, "extra content")
+        self.assertFalse(genio.are_files_equal(source, dest))
+
+
+class TestGenioRealWorldScenarios(TestCaseTmpDir):
+    """Functional tests simulating real-world usage scenarios."""
+
+    def test_config_file_modification_workflow(self):
+        """Test complete workflow: read config, modify value, verify change."""
+        config_file = os.path.join(self.tmpdir.name, "app.conf")
+        initial_config = "debug=false\nport=8080\nhost=localhost\n"
+        genio.write_file(config_file, initial_config)
+
+        # Read, modify, write pattern
+        content = genio.read_file(config_file)
+        modified_content = content.replace("debug=false", "debug=true")
+        genio.write_file(config_file, modified_content)
+
+        # Verify modification
+        self.assertTrue(genio.is_pattern_in_file(config_file, "debug=true"))
+        self.assertFalse(genio.is_pattern_in_file(config_file, "debug=false"))
+
+    def test_log_aggregation_workflow(self):
+        """Test analyzing a log file and counting different log levels."""
+        log_file = os.path.join(self.tmpdir.name, "app.log")
+        log_entries = [
+            "[2024-01-01 10:00:00] INFO: Application started",
+            "[2024-01-01 10:00:01] WARNING: Low memory",
+            "[2024-01-01 10:00:02] ERROR: Database connection failed",
+            "[2024-01-01 10:00:03] INFO: Retrying...",
+            "[2024-01-01 10:00:04] INFO: Connection restored",
+        ]
+        genio.write_file(log_file, "\n".join(log_entries) + "\n")
+
+        # Count different log levels
+        errors = genio.read_line_with_matching_pattern(log_file, "ERROR:")
+        warnings = genio.read_line_with_matching_pattern(log_file, "WARNING:")
+        infos = genio.read_line_with_matching_pattern(log_file, "INFO:")
+
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(len(warnings), 1)
+        self.assertEqual(len(infos), 3)
+
+    def test_incremental_logging_workflow(self):
+        """Test simulating incremental log file building."""
+        log_file = os.path.join(self.tmpdir.name, "events.log")
+        events = ["Event 1 occurred", "Event 2 occurred", "Event 3 occurred"]
+
+        for event in events:
+            genio.append_one_line(log_file, event)
+
+        all_events = genio.read_all_lines(log_file)
+        self.assertEqual(all_events, events)
+
+    def test_csv_data_verification_workflow(self):
+        """Test verifying CSV file structure and content."""
+        data_file = os.path.join(self.tmpdir.name, "data.csv")
+        csv_content = "name,age,city\nAlice,30,NYC\nBob,25,LA\nCharlie,35,Chicago\n"
+        genio.write_file(data_file, csv_content)
+
+        # Verify header
+        first_line = genio.read_one_line(data_file)
+        self.assertEqual(first_line, "name,age,city")
+
+        # Verify data row pattern
+        self.assertTrue(genio.is_pattern_in_file(data_file, r"^\w+,\d+,\w+$"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/modules/file/genio.py
+++ b/tests/unit/modules/file/genio.py
@@ -1,0 +1,262 @@
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from autils.file import genio
+from tests.utils import setup_autils_loggers, temp_dir_prefix
+
+setup_autils_loggers()
+
+
+class TestGenIOError(unittest.TestCase):
+    """Tests for the GenIOError exception class."""
+
+    def test_genio_error_behavior(self):
+        """Test GenIOError is a proper exception with message support."""
+        self.assertTrue(issubclass(genio.GenIOError, Exception))
+        error = genio.GenIOError("test error message")
+        self.assertEqual(str(error), "test error message")
+
+
+class TestAsk(unittest.TestCase):
+    """Tests for the ask function."""
+
+    def test_ask_auto_returns_y(self):
+        """Test that auto=True returns 'y' without prompting."""
+        result = genio.ask("Do you want to continue?", auto=True)
+        self.assertEqual(result, "y")
+
+    @mock.patch("builtins.input", return_value="n")
+    def test_ask_prompts_user(self, mock_input):
+        """Test that ask prompts user and returns their input."""
+        result = genio.ask("Continue?", auto=False)
+        self.assertEqual(result, "n")
+        mock_input.assert_called_once_with("Continue? (y/n) ")
+
+
+class TestReadFile(unittest.TestCase):
+    """Tests for the read_file function."""
+
+    def test_read_file_returns_content(self):
+        """Test reading file content including multiline and unicode."""
+        with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", delete=False) as f:
+            f.write("Line 1\nLine 2\n日本語 🎉")
+            f.flush()
+            content = genio.read_file(f.name)
+        os.unlink(f.name)
+        self.assertEqual(content, "Line 1\nLine 2\n日本語 🎉")
+
+    def test_read_file_empty(self):
+        """Test reading an empty file returns empty string."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+            f.flush()
+            content = genio.read_file(f.name)
+        os.unlink(f.name)
+        self.assertEqual(content, "")
+
+    def test_read_file_nonexistent_raises(self):
+        """Test that reading a nonexistent file raises FileNotFoundError."""
+        with self.assertRaises(FileNotFoundError):
+            genio.read_file("/nonexistent/path/to/file.txt")
+
+
+class TestReadOneLine(unittest.TestCase):
+    """Tests for the read_one_line function."""
+
+    def test_read_one_line_returns_first_line_stripped(self):
+        """Test reading first line with newline stripped."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+            f.write("First line\nSecond line\n")
+            f.flush()
+            line = genio.read_one_line(f.name)
+        os.unlink(f.name)
+        self.assertEqual(line, "First line")
+
+    def test_read_one_line_empty_file(self):
+        """Test reading from an empty file returns empty string."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+            f.flush()
+            line = genio.read_one_line(f.name)
+        os.unlink(f.name)
+        self.assertEqual(line, "")
+
+
+class TestReadAllLines(unittest.TestCase):
+    """Tests for the read_all_lines function."""
+
+    def test_read_all_lines_returns_list_stripped(self):
+        """Test reading all lines with newlines stripped."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+            f.write("Line 1\nLine 2\nLine 3\n")
+            f.flush()
+            lines = genio.read_all_lines(f.name)
+        os.unlink(f.name)
+        self.assertEqual(lines, ["Line 1", "Line 2", "Line 3"])
+
+    def test_read_all_lines_graceful_on_error(self):
+        """Test that errors return empty list instead of raising."""
+        # Nonexistent file
+        self.assertEqual(genio.read_all_lines("/nonexistent/path/file.txt"), [])
+        # Directory path causes error
+        self.assertEqual(genio.read_all_lines("/"), [])
+
+
+class TestReadLineWithMatchingPattern(unittest.TestCase):
+    """Tests for the read_line_with_matching_pattern function."""
+
+    def test_matching_pattern_finds_lines(self):
+        """Test finding matching lines with newlines stripped."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+            f.write("ERROR: First\nINFO: Middle\nERROR: Second\n")
+            f.flush()
+            matches = genio.read_line_with_matching_pattern(f.name, "ERROR")
+        os.unlink(f.name)
+        self.assertEqual(len(matches), 2)
+        self.assertNotIn("\n", matches[0])
+
+    def test_matching_pattern_no_match(self):
+        """Test that no matches returns empty list."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+            f.write("INFO: Something\nDEBUG: Another\n")
+            f.flush()
+            matches = genio.read_line_with_matching_pattern(f.name, "ERROR")
+        os.unlink(f.name)
+        self.assertEqual(matches, [])
+
+
+class TestWriteFile(unittest.TestCase):
+    """Tests for the write_file function."""
+
+    def test_write_file_creates_and_overwrites(self):
+        """Test writing creates file and overwrites existing content."""
+        prefix = temp_dir_prefix(self)
+        tmpdir = tempfile.mkdtemp(prefix=prefix)
+        filename = os.path.join(tmpdir, "test.txt")
+        # Create new file
+        genio.write_file(filename, "Original")
+        self.assertEqual(genio.read_file(filename), "Original")
+        # Overwrite
+        genio.write_file(filename, "New 日本語 🎉")
+        self.assertEqual(genio.read_file(filename), "New 日本語 🎉")
+        os.unlink(filename)
+        os.rmdir(tmpdir)
+
+
+class TestWriteOneLine(unittest.TestCase):
+    """Tests for the write_one_line function."""
+
+    def test_write_one_line_adds_single_newline(self):
+        """Test that write_one_line adds exactly one newline."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+            filename = f.name
+        # Without trailing newline
+        genio.write_one_line(filename, "Line")
+        self.assertEqual(genio.read_file(filename), "Line\n")
+        # With trailing newline - should not double
+        genio.write_one_line(filename, "Line\n")
+        self.assertEqual(genio.read_file(filename), "Line\n")
+        os.unlink(filename)
+
+
+class TestWriteFileOrFail(unittest.TestCase):
+    """Tests for the write_file_or_fail function."""
+
+    def test_write_file_or_fail_success(self):
+        """Test successful write."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+            filename = f.name
+        genio.write_file_or_fail(filename, "Success content")
+        self.assertEqual(genio.read_file(filename), "Success content")
+        os.unlink(filename)
+
+    def test_write_file_or_fail_raises_genioerror(self):
+        """Test that GenIOError is raised with details on failure."""
+        bad_path = "/nonexistent/directory/file.txt"
+        with self.assertRaises(genio.GenIOError) as context:
+            genio.write_file_or_fail(bad_path, "content")
+        self.assertIn(bad_path, str(context.exception))
+
+
+class TestAppendFile(unittest.TestCase):
+    """Tests for the append_file function."""
+
+    def test_append_file_appends_content(self):
+        """Test appending to existing file and creating new file."""
+        prefix = temp_dir_prefix(self)
+        tmpdir = tempfile.mkdtemp(prefix=prefix)
+        filename = os.path.join(tmpdir, "append.txt")
+        # Creates new file
+        genio.append_file(filename, "First")
+        genio.append_file(filename, " Second")
+        self.assertEqual(genio.read_file(filename), "First Second")
+        os.unlink(filename)
+        os.rmdir(tmpdir)
+
+
+class TestAppendOneLine(unittest.TestCase):
+    """Tests for the append_one_line function."""
+
+    def test_append_one_line_adds_newlines(self):
+        """Test that append_one_line adds exactly one newline per call."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+            filename = f.name
+        genio.append_one_line(filename, "Line 1")
+        genio.append_one_line(filename, "Line 2\n")  # Should not double newline
+        self.assertEqual(genio.read_file(filename), "Line 1\nLine 2\n")
+        os.unlink(filename)
+
+
+class TestIsPatternInFile(unittest.TestCase):
+    """Tests for the is_pattern_in_file function."""
+
+    def test_pattern_matching_with_regex(self):
+        """Test regex pattern matching returns True/False correctly."""
+        with tempfile.NamedTemporaryFile(mode="w") as temp_file:
+            temp_file.write("Line 1\n123\nLine 3\n")
+            temp_file.seek(0)
+            # Matches
+            self.assertTrue(genio.is_pattern_in_file(temp_file.name, r"\d{3}"))
+            self.assertTrue(genio.is_pattern_in_file(temp_file.name, "Line"))
+            # No match
+            self.assertFalse(genio.is_pattern_in_file(temp_file.name, r"\D{10}"))
+
+    def test_pattern_in_file_raises_for_invalid_file(self):
+        """Test that GenIOError is raised for directory or nonexistent file."""
+        prefix = temp_dir_prefix(self)
+        tempdirname = tempfile.mkdtemp(prefix=prefix)
+        with self.assertRaises(genio.GenIOError):
+            genio.is_pattern_in_file(tempdirname, "something")
+        os.rmdir(tempdirname)
+        with self.assertRaises(genio.GenIOError):
+            genio.is_pattern_in_file("/nonexistent/file.txt", "pattern")
+
+
+class TestAreFilesEqual(unittest.TestCase):
+    """Tests for the are_files_equal function."""
+
+    def test_are_files_equal_compares_by_hash(self):
+        """Test file comparison using hash - identical, different, and same file."""
+        file_1 = tempfile.NamedTemporaryFile(  # pylint: disable=consider-using-with
+            mode="w", delete=False
+        )
+        file_2 = tempfile.NamedTemporaryFile(  # pylint: disable=consider-using-with
+            mode="w", delete=False
+        )
+        # Identical content
+        for f in [file_1, file_2]:
+            f.write("Same content")
+            f.close()
+        self.assertTrue(genio.are_files_equal(file_1.name, file_2.name))
+        # Same file compared to itself
+        self.assertTrue(genio.are_files_equal(file_1.name, file_1.name))
+        # Different content
+        with open(file_2.name, "w", encoding="utf-8") as f:
+            f.write("Different")
+        self.assertFalse(genio.are_files_equal(file_1.name, file_2.name))
+        os.unlink(file_1.name)
+        os.unlink(file_2.name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add genio module to autils/file/ category with comprehensive unit and functional tests. The module provides generic IO operations for file reading, writing, appending, and pattern matching.

Files added:
- autils/file/genio.py - Main module (line-for-line from avocado)
- metadata/file/genio.yml - Module metadata
- tests/unit/modules/file/genio.py - 21 unit tests
- tests/functional/modules/file/genio.py - 13 functional tests
- docs/source/utils.rst - Documentation entry

Note: Requires crypto module to be merged first (dependency).

Assisted-By: Cursor-Claude-Opus-4.5