### PR TITLE
Migration of ovs Module

### DIFF
--- a/autils/network/drivers/ovs.py
+++ b/autils/network/drivers/ovs.py
@@ -1,0 +1,71 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; specifically version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat (c) 2024 and Avocado contributors
+# Author: Houqi Zuo <hzuo@redhat.com>
+
+"""Module with Open vSwitch (OVS) functions.
+
+This module provides utility functions for managing Open vSwitch bridges
+using the ovs-vsctl command-line tool.
+
+Note:
+    These functions require the Open vSwitch software to be installed
+    and the ovs-vsctl command to be available in the system PATH.
+    Some operations may require appropriate privileges depending on
+    the OVS configuration.
+"""
+from autils.devel import process
+
+
+def ovs_br_exists(brname):
+    """
+    Check if bridge exists or not.
+
+    :param brname: Name of the bridge.
+    :type brname: String.
+
+    :return: True if found, otherwise, return False.
+    :rtype: Boolean.
+
+    :raise: RuntimeError if executing command fails.
+    """
+    cmd = "ovs-vsctl br-exists %s" % brname
+    cmd_obj = process.run(cmd, shell=True)
+    status = cmd_obj.exit_status
+    if status != 0:
+        return False
+    return True
+
+
+def add_ovs_bridge(brname):
+    """
+    Add a bridge.
+
+    :param brname: Name of the bridge.
+    :type brname: String.
+
+    :raise: RuntimeError if executing command fails.
+    """
+    cmd = "ovs-vsctl --may-exist add-br %s" % brname
+    process.run(cmd, shell=True)
+
+
+def del_ovs_bridge(brname):
+    """
+    Delete a bridge from ovs.
+
+    :param brname: Name of the bridge.
+    :type brname: String.
+
+    :raise: RuntimeError if executing command fails.
+    """
+    cmd = "ovs-vsctl --if-exists del-br %s" % brname
+    process.run(cmd, shell=True)

--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -16,6 +16,11 @@ Ports
 -----
 .. automodule:: autils.network.ports
 
+Drivers
+-------
+ovs
+~~~
+.. automodule:: autils.network.drivers.ovs
 
 File
 =======

--- a/metadata/network/drivers/ovs.yml
+++ b/metadata/network/drivers/ovs.yml
@@ -1,0 +1,18 @@
+name: ovs
+description: Module for Open vSwitch related functions
+
+categories:
+  - Network
+  - Virtualization
+maintainers:
+  - name: Houqi Zuo
+    email: hzuo@redhat.com
+    github_usr_name: nickzhq
+supported_platforms:
+  - CentOS Stream 9
+  - Fedora 36
+  - Fedora 37
+tests:
+  - tests/unit/modules/network/drivers/ovs.py
+  - tests/functional/modules/network/drivers/ovs.py
+remote: false

--- a/tests/functional/modules/network/drivers/ovs.py
+++ b/tests/functional/modules/network/drivers/ovs.py
@@ -1,0 +1,95 @@
+import unittest
+
+from autils.devel import process
+from autils.file import path
+from autils.network.drivers import ovs
+
+
+def ovs_vsctl_available():
+    """Check if ovs-vsctl command is available."""
+    try:
+        path.find_command("ovs-vsctl")
+        return True
+    except path.CmdNotFoundError:
+        return False
+
+
+def can_run_ovs_commands():
+    """Check if we can run basic ovs-vsctl commands."""
+    if not ovs_vsctl_available():
+        return False
+    try:
+        # Try a simple read-only command that should work without root
+        process.run("ovs-vsctl show", ignore_status=True, shell=True)
+        return True
+    except process.CmdError:
+        return False
+
+
+class OvsTest(unittest.TestCase):
+    """Functional checks for :mod:`autils.network.drivers.ovs`."""
+
+    def setUp(self):
+        """Set up test bridge name that's unlikely to conflict."""
+        self.test_bridge = "test-br-aautils-func"
+        # Clean up any leftover bridge from previous runs
+        if ovs_vsctl_available() and can_run_ovs_commands():
+            try:
+                ovs.del_ovs_bridge(self.test_bridge)
+            except process.CmdError:
+                pass  # Bridge may not exist, which is fine
+
+    def tearDown(self):
+        """Clean up test bridge."""
+        if ovs_vsctl_available() and can_run_ovs_commands():
+            try:
+                ovs.del_ovs_bridge(self.test_bridge)
+            except process.CmdError:
+                pass  # Best effort cleanup
+
+    @unittest.skipUnless(ovs_vsctl_available(), "ovs-vsctl command not available")
+    @unittest.skipUnless(can_run_ovs_commands(), "Cannot run ovs-vsctl commands")
+    def test_ovs_br_exists_false_for_nonexistent_bridge(self):
+        """Test ovs_br_exists returns False for non-existent bridge."""
+        # Ensure bridge doesn't exist
+        self.assertFalse(ovs.ovs_br_exists("nonexistent-bridge-12345"))
+
+    @unittest.skipUnless(ovs_vsctl_available(), "ovs-vsctl command not available")
+    @unittest.skipUnless(can_run_ovs_commands(), "Cannot run ovs-vsctl commands")
+    def test_bridge_lifecycle(self):
+        """Test complete bridge lifecycle: add, exists, delete."""
+        # Initially, bridge should not exist
+        self.assertFalse(ovs.ovs_br_exists(self.test_bridge))
+
+        # Add the bridge
+        try:
+            ovs.add_ovs_bridge(self.test_bridge)
+            # Bridge should now exist
+            self.assertTrue(ovs.ovs_br_exists(self.test_bridge))
+        except process.CmdError as e:
+            # If we can't create bridges (e.g., no root access or OVS daemon not running)
+            self.skipTest(f"Cannot create OVS bridge: {e}")
+
+        # Delete the bridge
+        ovs.del_ovs_bridge(self.test_bridge)
+        # Bridge should no longer exist
+        self.assertFalse(ovs.ovs_br_exists(self.test_bridge))
+
+    def test_functions_without_ovs_installed(self):
+        """Test that functions fail appropriately when OVS is not available."""
+        if ovs_vsctl_available():
+            self.skipTest("OVS is available, skipping unavailability test")
+
+        # When ovs-vsctl is not available, functions should raise appropriate errors
+        with self.assertRaises((process.CmdError, FileNotFoundError, OSError)):
+            ovs.ovs_br_exists("test")
+
+        with self.assertRaises((process.CmdError, FileNotFoundError, OSError)):
+            ovs.add_ovs_bridge("test")
+
+        with self.assertRaises((process.CmdError, FileNotFoundError, OSError)):
+            ovs.del_ovs_bridge("test")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/modules/network/drivers/ovs.py
+++ b/tests/unit/modules/network/drivers/ovs.py
@@ -1,0 +1,78 @@
+import unittest.mock
+
+from autils.devel import process
+from autils.network.drivers import ovs
+
+
+class OvsTest(unittest.TestCase):
+    @unittest.mock.patch("autils.network.drivers.ovs.process.run")
+    def test_ovs_br_exists_true(self, mock_run):
+        """Test ovs_br_exists when bridge exists"""
+        mock_result = unittest.mock.MagicMock()
+        mock_result.exit_status = 0
+        mock_run.return_value = mock_result
+
+        result = ovs.ovs_br_exists("br0")
+
+        self.assertTrue(result)
+        mock_run.assert_called_once_with("ovs-vsctl br-exists br0", shell=True)
+
+    @unittest.mock.patch("autils.network.drivers.ovs.process.run")
+    def test_ovs_br_exists_false(self, mock_run):
+        """Test ovs_br_exists when bridge doesn't exist"""
+        mock_result = unittest.mock.MagicMock()
+        mock_result.exit_status = 1
+        mock_run.return_value = mock_result
+
+        result = ovs.ovs_br_exists("nonexistent")
+
+        self.assertFalse(result)
+        mock_run.assert_called_once_with("ovs-vsctl br-exists nonexistent", shell=True)
+
+    @unittest.mock.patch("autils.network.drivers.ovs.process.run")
+    def test_add_ovs_bridge(self, mock_run):
+        """Test add_ovs_bridge function"""
+        bridge_name = "test-bridge"
+
+        ovs.add_ovs_bridge(bridge_name)
+
+        expected_cmd = f"ovs-vsctl --may-exist add-br {bridge_name}"
+        mock_run.assert_called_once_with(expected_cmd, shell=True)
+
+    @unittest.mock.patch("autils.network.drivers.ovs.process.run")
+    def test_del_ovs_bridge(self, mock_run):
+        """Test del_ovs_bridge function"""
+        bridge_name = "test-bridge"
+
+        ovs.del_ovs_bridge(bridge_name)
+
+        expected_cmd = f"ovs-vsctl --if-exists del-br {bridge_name}"
+        mock_run.assert_called_once_with(expected_cmd, shell=True)
+
+    @unittest.mock.patch("autils.network.drivers.ovs.process.run")
+    def test_ovs_br_exists_cmd_error(self, mock_run):
+        """Test ovs_br_exists when process.run raises CmdError"""
+        mock_run.side_effect = process.CmdError("ovs-vsctl br-exists test", None, "Command failed")
+
+        with self.assertRaises(process.CmdError):
+            ovs.ovs_br_exists("test")
+
+    @unittest.mock.patch("autils.network.drivers.ovs.process.run")
+    def test_add_ovs_bridge_cmd_error(self, mock_run):
+        """Test add_ovs_bridge when process.run raises CmdError"""
+        mock_run.side_effect = process.CmdError("ovs-vsctl --may-exist add-br test", None, "Command failed")
+
+        with self.assertRaises(process.CmdError):
+            ovs.add_ovs_bridge("test")
+
+    @unittest.mock.patch("autils.network.drivers.ovs.process.run")
+    def test_del_ovs_bridge_cmd_error(self, mock_run):
+        """Test del_ovs_bridge when process.run raises CmdError"""
+        mock_run.side_effect = process.CmdError("ovs-vsctl --if-exists del-br test", None, "Command failed")
+
+        with self.assertRaises(process.CmdError):
+            ovs.del_ovs_bridge("test")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Migration of ovs Module:
From: avocado-vt/virttest/vt_utils/net/drivers/ovs.py 
To: aautils/autils/network/drivers/ovs.py

Improved Unit/Functional / RST Docstrings