### PR TITLE
Crypto Module Migration

### DIFF
--- a/autils/file/crypto.py
+++ b/autils/file/crypto.py
@@ -1,0 +1,80 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2013-2014
+# Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
+
+"""Cryptographic hash utilities for file verification."""
+
+import hashlib
+import io
+import logging
+import os
+
+LOG = logging.getLogger(__name__)
+
+
+def hash_file(filename, size=None, algorithm="md5"):
+    """Calculate the hash value of a file.
+
+    Computes a cryptographic hash of the specified file using the given
+    algorithm. Optionally limits hashing to the first N bytes of the file,
+    which is useful for verifying partial downloads or large files.
+
+    :param filename: Path of the file that will have its hash calculated.
+    :type filename: str
+    :param size: If provided, hash only the first size bytes of the file.
+        If None or 0, the entire file is hashed. If size exceeds the file
+        size, the entire file is hashed.
+    :type size: int or None
+    :param algorithm: Hash algorithm to use. Supported algorithms include
+        md5, sha1, sha256, sha512, blake2b, and others available in hashlib.
+    :type algorithm: str
+    :return: Hexadecimal digest string of the computed hash. Returns None
+        if an invalid algorithm is specified.
+    :rtype: str or None
+    :raises FileNotFoundError: When the specified file does not exist.
+    :raises PermissionError: When the file cannot be read due to permissions.
+
+    Example::
+
+        >>> hash_file('/path/to/file')
+        'abc123...'
+        >>> hash_file('/path/to/file', algorithm='sha256')
+        'e3b0c44298fc1c149afbf4c8996fb924...'
+        >>> hash_file('/path/to/large_file', size=1024)
+        'abc123...'
+    """
+    chunksize = io.DEFAULT_BUFFER_SIZE
+    fsize = os.path.getsize(filename)
+
+    if not size or size > fsize:
+        size = fsize
+
+    try:
+        hash_obj = hashlib.new(algorithm)
+    except ValueError as detail:
+        LOG.error(
+            'Returning "None" due to inability to create hash object: "%s"', detail
+        )
+        return None
+
+    with open(filename, "rb") as file_to_hash:
+        while size > 0:
+            chunksize = min(chunksize, size)
+            data = file_to_hash.read(chunksize)
+            if not data:
+                LOG.debug("Nothing left to read but size=%d", size)
+                break
+            hash_obj.update(data)
+            size -= len(data)
+
+    return hash_obj.hexdigest()

--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -20,6 +20,10 @@ Ports
 File
 =======
 
+Crypto
+------
+.. automodule:: autils.file.crypto
+
 Path
 ----
 .. automodule:: autils.file.path

--- a/metadata/file/crypto.yml
+++ b/metadata/file/crypto.yml
@@ -1,0 +1,18 @@
+name: crypto
+description: Cryptographic hash utilities for file verification.
+
+categories:
+  - Files
+  - Security
+maintainers:
+  - name: Harvey James Lynden
+    email: hlynden@redhat.com
+    github_usr_name: harvey0100
+supported_platforms:
+  - CentOS Stream 9
+  - Fedora 36
+  - Fedora 37
+tests:
+  - tests/unit/modules/file/crypto.py
+  - tests/functional/modules/file/crypto.py
+remote: false

--- a/tests/functional/modules/file/crypto.py
+++ b/tests/functional/modules/file/crypto.py
@@ -1,0 +1,101 @@
+# pylint: disable=duplicate-code
+import hashlib
+import os
+import unittest
+
+from autils.file import crypto
+from tests.utils import TestCaseTmpDir, setup_autils_loggers
+
+setup_autils_loggers()
+
+
+class HashFileFunctionalTest(TestCaseTmpDir):
+    """Functional tests for crypto.hash_file with real-world scenarios."""
+
+    def test_download_verification_with_known_checksums(self):
+        """
+        Test verifying a downloaded file against published checksums.
+
+        Real-world scenario: Package managers and download sites publish
+        checksums that users verify after downloading. This test uses
+        a well-known test vector with pre-computed checksums.
+        """
+        content = b"The quick brown fox jumps over the lazy dog"
+        filepath = os.path.join(self.tmpdir.name, "downloaded_file.bin")
+        with open(filepath, "wb") as f:
+            f.write(content)
+
+        self.assertEqual(
+            crypto.hash_file(filepath, algorithm="md5"),
+            "9e107d9d372bb6826bd81d3542a419d6",
+        )
+        self.assertEqual(
+            crypto.hash_file(filepath, algorithm="sha256"),
+            "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592",
+        )
+
+    def test_file_tampering_detection(self):
+        """
+        Test detecting file modification through hash comparison.
+
+        Real-world scenario: Security systems use hashes to detect if
+        files have been tampered with. This tests the complete workflow.
+        """
+        filepath = os.path.join(self.tmpdir.name, "secure_config.conf")
+
+        with open(filepath, "wb") as f:
+            f.write(b"secure_setting=true\npassword_hash=abc123")
+        original_hash = crypto.hash_file(filepath, algorithm="sha256")
+
+        with open(filepath, "wb") as f:
+            f.write(b"secure_setting=false\npassword_hash=abc123")
+        tampered_hash = crypto.hash_file(filepath, algorithm="sha256")
+
+        self.assertNotEqual(original_hash, tampered_hash)
+
+    def test_create_file_manifest(self):
+        """
+        Test creating a manifest of file checksums for a directory.
+
+        Real-world scenario: Build systems and package managers create
+        manifests listing checksums of all files for verification.
+        """
+        files = {
+            "src/main.py": b"print('hello')",
+            "src/utils.py": b"def helper(): pass",
+            "data/config.json": b'{"key": "value"}',
+        }
+
+        manifest = {}
+        for relpath, content in files.items():
+            filepath = os.path.join(self.tmpdir.name, relpath)
+            os.makedirs(os.path.dirname(filepath), exist_ok=True)
+            with open(filepath, "wb") as f:
+                f.write(content)
+            manifest[relpath] = crypto.hash_file(filepath, algorithm="sha256")
+
+        for relpath, content in files.items():
+            expected = hashlib.sha256(content).hexdigest()
+            self.assertEqual(manifest[relpath], expected)
+
+        self.assertEqual(len(set(manifest.values())), len(files))
+
+    def test_symlink_follows_to_target(self):
+        """
+        Test that hashing through symlink produces same result as original.
+
+        Real-world scenario: Linux systems use symlinks extensively;
+        hash verification must work regardless of access path.
+        """
+        original = os.path.join(self.tmpdir.name, "original.bin")
+        symlink = os.path.join(self.tmpdir.name, "link.bin")
+
+        with open(original, "wb") as f:
+            f.write(b"Linked content")
+        os.symlink(original, symlink)
+
+        self.assertEqual(crypto.hash_file(original), crypto.hash_file(symlink))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/functional/modules/file/crypto.py
+++ b/tests/functional/modules/file/crypto.py
@@ -34,25 +34,6 @@ class HashFileFunctionalTest(TestCaseTmpDir):
             "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592",
         )
 
-    def test_file_tampering_detection(self):
-        """
-        Test detecting file modification through hash comparison.
-
-        Real-world scenario: Security systems use hashes to detect if
-        files have been tampered with. This tests the complete workflow.
-        """
-        filepath = os.path.join(self.tmpdir.name, "secure_config.conf")
-
-        with open(filepath, "wb") as f:
-            f.write(b"secure_setting=true\npassword_hash=abc123")
-        original_hash = crypto.hash_file(filepath, algorithm="sha256")
-
-        with open(filepath, "wb") as f:
-            f.write(b"secure_setting=false\npassword_hash=abc123")
-        tampered_hash = crypto.hash_file(filepath, algorithm="sha256")
-
-        self.assertNotEqual(original_hash, tampered_hash)
-
     def test_create_file_manifest(self):
         """
         Test creating a manifest of file checksums for a directory.
@@ -79,22 +60,6 @@ class HashFileFunctionalTest(TestCaseTmpDir):
             self.assertEqual(manifest[relpath], expected)
 
         self.assertEqual(len(set(manifest.values())), len(files))
-
-    def test_symlink_follows_to_target(self):
-        """
-        Test that hashing through symlink produces same result as original.
-
-        Real-world scenario: Linux systems use symlinks extensively;
-        hash verification must work regardless of access path.
-        """
-        original = os.path.join(self.tmpdir.name, "original.bin")
-        symlink = os.path.join(self.tmpdir.name, "link.bin")
-
-        with open(original, "wb") as f:
-            f.write(b"Linked content")
-        os.symlink(original, symlink)
-
-        self.assertEqual(crypto.hash_file(original), crypto.hash_file(symlink))
 
 
 if __name__ == "__main__":

--- a/tests/unit/modules/file/crypto.py
+++ b/tests/unit/modules/file/crypto.py
@@ -1,0 +1,117 @@
+# pylint: disable=duplicate-code
+import hashlib
+import os
+import unittest
+
+from autils.file import crypto
+from tests.utils import TestCaseTmpDir, setup_autils_loggers
+
+setup_autils_loggers()
+
+
+class HashFileTest(TestCaseTmpDir):
+    """Test cases for crypto.hash_file function."""
+
+    def _create_test_file(self, content, filename="testfile"):
+        """Helper to create a test file with given content."""
+        filepath = os.path.join(self.tmpdir.name, filename)
+        with open(filepath, "wb") as f:
+            f.write(content)
+        return filepath
+
+    # Core algorithm tests - testing the algorithm parameter code path
+    def test_hash_file_md5_default(self):
+        """Test MD5 hash calculation with default algorithm."""
+        content = b"Hello, World!"
+        filepath = self._create_test_file(content)
+        expected = hashlib.md5(content).hexdigest()
+        result = crypto.hash_file(filepath)
+        self.assertEqual(result, expected)
+
+    def test_hash_file_sha256(self):
+        """Test SHA256 hash calculation."""
+        content = b"Test content for SHA256"
+        filepath = self._create_test_file(content)
+        expected = hashlib.sha256(content).hexdigest()
+        result = crypto.hash_file(filepath, algorithm="sha256")
+        self.assertEqual(result, expected)
+
+    # Size parameter tests - each tests a distinct code path
+    def test_hash_file_with_size_limit(self):
+        """Test hashing only the first N bytes of a file."""
+        content = b"ABCDEFGHIJ"  # 10 bytes
+        filepath = self._create_test_file(content)
+        # Hash only first 5 bytes - tests size < file_size path
+        expected = hashlib.md5(b"ABCDE").hexdigest()
+        result = crypto.hash_file(filepath, size=5)
+        self.assertEqual(result, expected)
+
+    def test_hash_file_size_larger_than_file(self):
+        """Test that size larger than file hashes the whole file."""
+        content = b"Small file"
+        filepath = self._create_test_file(content)
+        expected = hashlib.md5(content).hexdigest()
+        # Request more bytes than file contains - tests size > file_size branch
+        result = crypto.hash_file(filepath, size=1000000)
+        self.assertEqual(result, expected)
+
+    def test_hash_file_size_falsy_hashes_whole_file(self):
+        """Test that falsy size values (None, 0) hash the entire file."""
+        content = b"Complete file content"
+        filepath = self._create_test_file(content)
+        expected = hashlib.md5(content).hexdigest()
+        # Both None and 0 are falsy - tests 'not size' branch
+        self.assertEqual(crypto.hash_file(filepath, size=None), expected)
+        self.assertEqual(crypto.hash_file(filepath, size=0), expected)
+
+    # Edge case tests - each tests unique behavior
+    def test_hash_file_empty_file(self):
+        """Test hashing an empty file."""
+        filepath = self._create_test_file(b"")
+        expected = hashlib.md5(b"").hexdigest()
+        result = crypto.hash_file(filepath)
+        self.assertEqual(result, expected)
+
+    def test_hash_file_binary_content(self):
+        """Test hashing a file with all possible byte values."""
+        content = bytes(range(256))  # All byte values 0-255
+        filepath = self._create_test_file(content)
+        expected = hashlib.md5(content).hexdigest()
+        result = crypto.hash_file(filepath)
+        self.assertEqual(result, expected)
+
+    def test_hash_file_larger_than_chunk_size(self):
+        """Test hashing a file that requires multiple read iterations."""
+        # Create content larger than io.DEFAULT_BUFFER_SIZE (typically 8192)
+        content = b"x" * 100000
+        filepath = self._create_test_file(content)
+        expected = hashlib.md5(content).hexdigest()
+        result = crypto.hash_file(filepath)
+        self.assertEqual(result, expected)
+
+    # Error handling tests
+    def test_hash_file_invalid_algorithm_returns_none(self):
+        """Test that invalid algorithm returns None without raising."""
+        content = b"Test content"
+        filepath = self._create_test_file(content)
+        result = crypto.hash_file(filepath, algorithm="invalid_algo")
+        self.assertIsNone(result)
+
+    def test_hash_file_nonexistent_file_raises(self):
+        """Test that non-existent file raises FileNotFoundError."""
+        nonexistent = os.path.join(self.tmpdir.name, "nonexistent_file.txt")
+        with self.assertRaises(FileNotFoundError):
+            crypto.hash_file(nonexistent)
+
+    # Hash uniqueness test - verifies hash function works correctly
+    def test_hash_file_different_content_produces_different_hash(self):
+        """Test that different content produces different hash values."""
+        filepath1 = self._create_test_file(b"Content A", filename="file1.txt")
+        filepath2 = self._create_test_file(b"Content B", filename="file2.txt")
+        hash1 = crypto.hash_file(filepath1)
+        hash2 = crypto.hash_file(filepath2)
+        self.assertNotEqual(hash1, hash2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Migrates the crypto module from avocado to autils. Adds hash_file() for file hashing, plus unit and functional tests, metadata, and docs. The implementation matches the avocado version, with the deprecation block removed and imports updated for autils.