### PR TITLE
Migrate cpu module from avocado to autils

### DIFF
--- a/autils/system/cpu.py
+++ b/autils/system/cpu.py
@@ -1,0 +1,725 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# This code was inspired in the autotest project,
+#
+# client/base_utils.py
+# Original author: Martin J Bligh <mbligh@google.com>
+# Original author: John Admanski <jadmanski@google.com>
+
+
+"""Utilities for querying and managing CPU information on the current machine.
+
+This module provides functions to read CPU details from /proc/cpuinfo and sysfs,
+including architecture, vendor, version, online/offline status, NUMA topology,
+and frequency governor settings. It supports x86_64, i386, powerpc, s390,
+aarch64, and other architectures.
+"""
+import glob
+import logging
+import os
+import platform
+import random
+import re
+import warnings
+
+from autils.devel import process
+from autils.file import genio
+
+#: Map vendor's name with expected string in /proc/cpuinfo.
+VENDORS_MAP = {
+    "intel": (b"GenuineIntel",),
+    "amd": (b"AMD",),
+    "ibm": (
+        rb"POWER\d",
+        rb"IBM/S390",
+        rb"Power\d",
+    ),
+}
+
+LOG = logging.getLogger(__name__)
+
+
+class FamilyException(Exception):
+    """Raised when CPU family cannot be determined for the current architecture."""
+
+
+def _list_matches(content_list, pattern):
+    """Check if any item in list matches the specified pattern.
+
+    :param content_list: items to match
+    :type content_list: list
+    :param pattern: pattern to match from content_list
+    :type pattern: str
+    :return: if the pattern was found or not
+    :rtype: bool
+    """
+    for content in content_list:
+        match = re.search(pattern, content)
+        if match:
+            return True
+    return False
+
+
+def _get_info():
+    """Return info on the 1st CPU entry from /proc/cpuinfo as a list of lines.
+
+    :return: `list` of lines 1st CPU entry from /proc/cpuinfo file
+    :rtype: list
+    """
+    cpuinfo = []
+    with open("/proc/cpuinfo", "rb") as proc_cpuinfo:  # pylint: disable=W1514
+        for line in proc_cpuinfo:
+            if line == b"\n" and len(cpuinfo) > 0:
+                break
+            cpuinfo.append(line)
+    return cpuinfo
+
+
+def _get_status(cpu):
+    """Check if a CPU is online or offline.
+
+    :param cpu: CPU number (e.g. 1, 2 or 39)
+    :type cpu: int
+    :return: `bool` True if online or False if not
+    :rtype: bool
+    """
+    with open(
+        f"/sys/devices/system/cpu/cpu{cpu}/online", "rb"
+    ) as cpu_online:  # pylint: disable=W1514
+        if b"1" in cpu_online.read():
+            return True
+    return False
+
+
+def cpu_has_flags(flags):
+    """Check if a list of flags are available on current CPU info.
+
+    :param flags: A `list` of cpu flags that must exists on the current CPU.
+    :type flags: list of str
+    :return: True if all the flags were found or False if not
+    :rtype: bool
+    """
+    cpu_info = _get_info()
+
+    if not isinstance(flags, list):
+        flags = [flags]
+
+    for flag in flags:
+        if not any(flag.encode() in line for line in cpu_info):
+            return False
+    return True
+
+
+def get_version():
+    """Get cpu version.
+
+    :return: cpu version of given machine
+             e.g.:- 'i5-5300U' for Intel and 'POWER9' for IBM machines in
+             case of unknown/unsupported machines, return an empty string.
+    :rtype: str
+    """
+    version_pattern = {
+        "x86_64": rb"\s([\S,\d]+)\sCPU",
+        "i386": rb"\s([\S,\d]+)\sCPU",
+        "powerpc": rb"revision\s+:\s+(\S+)",
+        "s390": rb".*machine\s=\s(\d+)",
+    }
+    cpu_info = _get_info()
+    arch = get_arch()
+    pattern = version_pattern.get(arch)
+    if not pattern:
+        LOG.warning("No pattern string for arch: %s", arch)
+        return ""
+
+    for line in cpu_info:
+        version_out = re.findall(pattern, line)
+        if version_out:
+            return version_out[0].decode("utf-8")
+    return ""
+
+
+def get_vendor():
+    """Get the current cpu vendor name.
+
+    :return: a key of :data:`VENDORS_MAP` (e.g. 'intel') depending on the
+             current CPU architecture. Return None if it was unable to
+             determine the vendor name.
+    :rtype: str or None
+    """
+    cpu_info = _get_info()
+    for vendor, identifiers in VENDORS_MAP.items():
+        for identifier in identifiers:
+            if _list_matches(cpu_info, identifier):
+                return vendor
+    return None
+
+
+def get_revision():
+    """Get revision from /proc/cpuinfo.
+
+    :return: Revision entry from /proc/cpuinfo (e.g. '0080' for IBM POWER10),
+             or None if no revision line is found.
+    :rtype: str or None
+    """
+    rev = None
+    proc_cpuinfo = genio.read_file("/proc/cpuinfo")
+    for line in proc_cpuinfo.splitlines():
+        if "revision" in line:
+            rev = line.split(" ")[3].strip()
+    return rev
+
+
+def get_va_bits():
+    """Get virtual address bit size from /proc/cpuinfo (x86).
+
+    :return: VA address bit size as string (e.g. '48'), or empty string
+             if not found or on non-x86 architectures.
+    :rtype: str
+    """
+    cpu_info = genio.read_file("/proc/cpuinfo")
+    for line in cpu_info.splitlines():
+        if "address sizes" in line:
+            return line.split()[-3].strip()
+    return ""
+
+
+def get_arch():
+    """Detect the CPU architecture of the current machine.
+
+    :return: Architecture string (e.g. 'x86_64', 'powerpc', 's390', 'aarch64').
+    :rtype: str
+    """
+    cpu_table = [
+        (b"^cpu.*(RS64|Broadband Engine)", "powerpc"),
+        (rb"^cpu.*POWER\d+", "powerpc"),
+        (rb"^cpu.*Power\d+", "powerpc"),
+        (b"^cpu.*PPC970", "powerpc"),
+        (
+            b"(ARM|^CPU implementer|^CPU part|^CPU variant"
+            b"|^Features|^BogoMIPS|^CPU revision)",
+            "arm",
+        ),
+        (
+            b"(^cpu MHz dynamic|^cpu MHz static|^features"
+            b"|^bogomips per cpu|^max thread id)",
+            "s390",
+        ),
+        (b"^type", "sparc64"),
+        (b"^flags.*:.* lm .*", "x86_64"),
+        (b"^flags", "i386"),
+        (b"^hart\\s*: 1$", "riscv"),
+    ]
+    cpuinfo = _get_info()
+    for pattern, arch in cpu_table:
+        if _list_matches(cpuinfo, pattern):
+            if arch != "arm":
+                return arch
+            # ARM is a special situation, which matches both 32 bits
+            # (v7) and 64 bits (v8).
+            for line in cpuinfo:
+                if line.startswith(b"CPU architecture"):
+                    version = int(line.split(b":", 1)[1])
+                    if version >= 8:
+                        return "aarch64"
+                    # For historical reasons return arm
+                    return "arm"
+    return platform.machine()
+
+
+def get_family():
+    """Get CPU family or microarchitecture name.
+
+    :return: Family string (e.g. 'broadwell', 'haswell', 'power8', 'power9',
+             'z15') depending on architecture.
+    :rtype: str
+    :raises FamilyException: When family cannot be determined.
+    :raises NotImplementedError: On unsupported architectures.
+    """
+    family = None
+    arch = get_arch()
+    if arch in ("x86_64", "i386"):
+        if get_vendor() == "amd":
+            cpu_info = _get_info()
+            pattern = r"cpu family\s*:"
+            for line in cpu_info:
+                line = line.decode("utf-8")
+                if re.search(pattern, line):
+                    family = int(line.split(":")[1])
+                    return family
+        try:
+            # refer below links for microarchitectures names
+            # https://en.wikipedia.org/wiki/List_of_Intel_CPU_microarchitectures
+            # https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/events/intel/core.c#n4613
+            with open(
+                "/sys/devices/cpu/caps/pmu_name", "rb"
+            ) as mico_arch:  # pylint: disable=W1514
+                family = mico_arch.read().decode("utf-8").strip("\n").lower()
+        except FileNotFoundError as err:
+            msg = f"Could not find micro-architecture/family, Error: {err}"
+            LOG.warning(msg)
+            raise FamilyException(msg) from err
+    elif arch == "powerpc":
+        res = []
+        try:
+            for line in _get_info():
+                res = re.findall(rb"cpu\s+:\s+(POWER\d+|Power\d+)", line, re.IGNORECASE)
+                if res:
+                    break
+            family = res[0].decode("utf-8").lower()
+        except IndexError as err:
+            msg = f"Unable to parse cpu family {err}"
+            LOG.warning(msg)
+            raise FamilyException(msg) from err
+    elif arch == "s390":
+        zfamily_map = {"2964": "z13", "3906": "z14", "8561": "z15", "3931": "z16"}
+        try:
+            family = zfamily_map[get_version()].lower()
+        except KeyError as err:
+            msg = f"Could not find family for {get_version()}\nError: {err}"
+            LOG.warning(msg)
+            raise FamilyException(msg) from err
+    else:
+        raise NotImplementedError
+    return family
+
+
+def get_model():
+    """Get CPU model number (x86 only).
+
+    :return: Model integer from /proc/cpuinfo, or None if not found.
+    :rtype: int or None
+    :raises NotImplementedError: On non-x86 architectures.
+    """
+    arch = get_arch()
+    if arch == "x86_64":
+        cpu_info = _get_info()
+        pattern = r"model\s*:"
+        for line in cpu_info:
+            line = line.decode("utf-8")
+            if re.search(pattern, line):
+                model = int(line.split(":")[1])
+                return model
+        return None
+    raise NotImplementedError
+
+
+def get_x86_amd_zen(family=None, model=None):
+    """Get the AMD Zen architecture version for x86 AMD CPUs.
+
+    :param family: AMD CPU family (default: from get_family()).
+    :type family: int or None
+    :param model: AMD CPU model (default: from get_model()).
+    :type model: int or None
+    :return: Zen generation (1-6), or None if not an AMD Zen CPU.
+    :rtype: int or None
+    """
+
+    x86_amd_zen = {
+        0x17: {
+            1: [(0x00, 0x2F), (0x50, 0x5F)],
+            2: [(0x30, 0x4F), (0x60, 0x7F), (0x90, 0x91), (0xA0, 0xAF)],
+        },
+        0x19: {3: [(0x00, 0x0F), (0x20, 0x5F)], 4: [(0x10, 0x1F), (0x60, 0xAF)]},
+        0x1A: {
+            5: [(0x00, 0x0F), (0x20, 0x2F), (0x40, 0x4F), (0x60, 0x7F)],
+            6: [(0x50, 0x5F), (0x80, 0xAF), (0xC0, 0xCF)],
+        },
+    }
+    if family is None:
+        family = get_family()
+    if model is None:
+        model = get_model()
+
+    for _family, _zen_model in x86_amd_zen.items():
+        if _family == family:
+            for _zen, _model in _zen_model.items():
+                if any(lower <= model <= upper for (lower, upper) in _model):
+                    return _zen
+    return None
+
+
+def online_list():
+    """Report a list of indexes of the online CPUs.
+
+    :return: List of online CPU indices.
+    :rtype: list of int
+    """
+    cpus = []
+    search_str = b"processor"
+    index = 2
+    if platform.machine() == "s390x":
+        search_str = b"cpu number"
+        index = 3
+    with open("/proc/cpuinfo", "rb") as proc_cpuinfo:  # pylint: disable=W1514
+        for line in proc_cpuinfo:
+            if line.startswith(search_str):
+                cpus.append(int(line.split()[index]))  # grab cpu number
+    return cpus
+
+
+def total_count():
+    """Return number of total CPUs in the system including offline CPUs.
+
+    :return: Total CPU count.
+    :rtype: int
+    """
+    return os.sysconf("SC_NPROCESSORS_CONF")
+
+
+def online_count():
+    """Return number of online CPUs in the system.
+
+    :return: Online CPU count.
+    :rtype: int
+    """
+    return os.sysconf("SC_NPROCESSORS_ONLN")
+
+
+def is_hotpluggable(cpu):
+    """Check whether a CPU can be hot-plugged (offlined/onlined).
+
+    :param cpu: CPU index to check.
+    :type cpu: int
+    :return: True if the CPU has an 'online' sysfs interface.
+    :rtype: bool
+    """
+    return os.path.exists(f"/sys/devices/system/cpu/cpu{cpu}/online")
+
+
+def online(cpu):
+    """Bring a CPU online.
+
+    :param cpu: CPU index to bring online.
+    :type cpu: int
+    :return: 1 on success, 0 on failure (requires root).
+    :rtype: int
+    """
+    if _get_status(cpu) is False:
+        with open(
+            f"/sys/devices/system/cpu/cpu{cpu}/online", "wb"
+        ) as fd:  # pylint: disable=W1514
+            fd.write(b"1")
+        if _get_status(cpu) is False:
+            return 0
+    return 1
+
+
+def offline(cpu):
+    """Take a CPU offline.
+
+    :param cpu: CPU index to take offline.
+    :type cpu: int
+    :return: 0 on success, 1 on failure (requires root).
+    :rtype: int
+    """
+    if _get_status(cpu):
+        with open(
+            f"/sys/devices/system/cpu/cpu{cpu}/online", "wb"
+        ) as fd:  # pylint: disable=W1514
+            fd.write(b"0")
+        if _get_status(cpu):
+            return 1
+    return 0
+
+
+def get_idle_state():
+    """Get current CPU idle state values.
+
+    :return: Dict of cpuidle state values for all CPUs
+    :rtype: dict
+    """
+    cpus_list = online_list()
+    states = len(glob.glob("/sys/devices/system/cpu/cpu0/cpuidle/state*"))
+    cpu_idlestate = {}
+    for cpu in cpus_list:
+        cpu_idlestate[cpu] = {}
+        for state_no in range(states):
+            state_file = (
+                f"/sys/devices/system/cpu/cpu{cpu}/cpuidle/state{state_no}/disable"
+            )
+            try:
+                with open(state_file, "rb") as fl:  # pylint: disable=W1514
+                    cpu_idlestate[cpu][state_no] = bool(int(fl.read()))
+            except IOError as err:
+                LOG.warning(
+                    "Failed to read idle state on cpu %s for state %s:\n%s",
+                    cpu,
+                    state_no,
+                    err,
+                )
+    return cpu_idlestate
+
+
+def _bool_to_binary(value):
+    """Turn a Python boolean value (True or False) into binary data.
+
+    This function is suitable for writing to /proc/* and /sys/* files.
+
+    :param value: Boolean to convert.
+    :type value: bool
+    :return: b'1' for True, b'0' for False.
+    :rtype: bytes
+    :raises TypeError: When value is not a boolean.
+    """
+    if value is True:
+        return b"1"
+    if value is False:
+        return b"0"
+    raise TypeError(f"Value is not a boolean: {value}")
+
+
+def set_idle_state(state_number="all", disable=True, setstate=None):
+    """Set or reset CPU idle states for all CPUs.
+
+    :param state_number: cpuidle state number, default: `all` all states
+    :type state_number: str
+    :param disable: whether to disable/enable given cpu idle state,
+                    default is to disable.
+    :type disable: bool
+    :param setstate: cpuidle state value, output of `get_idle_state()`
+    :type setstate: dict
+    """
+    cpus_list = online_list()
+    if not setstate:
+        states = []
+        if state_number == "all":
+            states = list(
+                range(len(glob.glob("/sys/devices/system/cpu/cpu0/cpuidle/state*")))
+            )
+        else:
+            states.append(state_number)
+        disable = _bool_to_binary(disable)
+        for cpu in cpus_list:
+            for state_no in states:
+                state_file = (
+                    f"/sys/devices/system/cpu/cpu{cpu}/cpuidle/state{state_no}/disable"
+                )
+                try:
+                    with open(state_file, "wb") as fl:  # pylint: disable=W1514
+                        fl.write(disable)
+                except IOError as err:
+                    LOG.warning(
+                        "Failed to set idle state on cpu %s for state %s:\n%s",
+                        cpu,
+                        state_no,
+                        err,
+                    )
+    else:
+        for cpu, stateval in setstate.items():
+            for state_no, value in stateval.items():
+                state_file = (
+                    f"/sys/devices/system/cpu/cpu{cpu}/cpuidle/state{state_no}/disable"
+                )
+                disable = _bool_to_binary(value)
+                try:
+                    with open(state_file, "wb") as fl:  # pylint: disable=W1514
+                        fl.write(disable)
+                except IOError as err:
+                    LOG.warning(
+                        "Failed to set idle state on cpu %s for state %s:\n%s",
+                        cpu,
+                        state_no,
+                        err,
+                    )
+
+
+def set_freq_governor(governor="random"):
+    """Change the CPU frequency governor for all CPUs.
+
+    :param governor: Governor name (e.g. 'performance', 'powersave'), or
+                     'random' to pick one randomly from available governors.
+    :type governor: str
+    :return: True on success, False on failure.
+    :rtype: bool
+    """
+    avl_gov_file = "/sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors"
+    cur_gov_file = "/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor"
+    cur_gov = get_freq_governor()
+    if not cur_gov:
+        return False
+    if not (os.access(avl_gov_file, os.R_OK) and os.access(cur_gov_file, os.W_OK)):
+        LOG.error(
+            "Could not locate frequency governor sysfs entries or\n"
+            " No proper permissions to read/write sysfs entries"
+        )
+        return False
+    cpus_list = total_count()
+    with open(avl_gov_file, "r") as fl:  # pylint: disable=W1514
+        avl_govs = fl.read().strip().split(" ")
+    if governor == "random":
+        avl_govs.remove(cur_gov)
+        if not avl_govs:
+            LOG.error("No other frequency governors to pick from...")
+            return False
+        governor = random.choice(avl_govs)
+    if governor not in avl_govs:
+        LOG.warning("Trying to change unknown frequency governor: %s", governor)
+    for cpu in range(cpus_list):
+        cur_gov_file = f"/sys/devices/system/cpu/cpu{cpu}/cpufreq/scaling_governor"
+        try:
+            with open(cur_gov_file, "w") as fl:  # pylint: disable=W1514
+                fl.write(governor)
+        except IOError as err:
+            LOG.warning(
+                "Unable to write a given frequency "
+                "governor %s profile for cpu "
+                "%s\n %s",
+                governor,
+                cpu,
+                err,
+            )
+    return True
+
+
+def get_freq_governor():
+    """Get the current CPU frequency governor.
+
+    :return: Governor name (e.g. 'performance'), or empty string on error.
+    :rtype: str
+    """
+    cur_gov_file = "/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor"
+    try:
+        with open(cur_gov_file, "r") as fl:  # pylint: disable=W1514
+            return fl.read().strip()
+    except IOError as err:
+        LOG.error("Unable to get the current governor\n %s", err)
+        return ""
+
+
+def get_pid_cpus(pid):
+    """Get CPU indices used by a process (from ``/proc/<pid>/task/*/stat``).
+
+    :param pid: Process ID.
+    :type pid: int or str
+    :return: List of CPU index strings the process threads are running on.
+    :rtype: list of str
+    """
+    # processor id index is defined according proc documentation
+    # the negative index is necessary because backward data
+    # access has no misleading whitespaces
+    processor_id_index = -14
+    cpus = set()
+    proc_stat_files = glob.glob(f"/proc/{pid}/task/[123456789]*/stat")
+
+    for proc_stat_file in proc_stat_files:
+        try:
+            with open(proc_stat_file) as proc_stat:  # pylint: disable=W1514
+                cpus.add(proc_stat.read().split(" ")[processor_id_index])
+        except IOError:
+            continue
+    return list(cpus)
+
+
+def get_numa_node_has_cpus():
+    """Get NUMA node numbers that have CPUs assigned.
+
+    :return: List of NUMA node identifiers that have CPUs.
+    :rtype: list of str
+    """
+    cpu_path = "/sys/devices/system/node/has_cpu"
+    delim = ",", "-"
+    regex_pat = "|".join(map(re.escape, delim))
+    read_cpu_path = genio.read_file(cpu_path).rstrip("\n")
+    nodes_with_cpus = re.split(regex_pat, read_cpu_path)
+    return nodes_with_cpus
+
+
+def numa_nodes_with_assigned_cpus():
+    """Get NUMA nodes with their associated CPU indices.
+
+    :return: Dict mapping NUMA node ID to sorted list of CPU indices.
+    :rtype: dict
+    """
+    numa_nodes_with_cpus = {}
+    for path in glob.glob("/sys/devices/system/node/node[0-9]*"):
+        node = int(re.search(r".node(\d+)$", path).group(1))
+        node_dir = os.path.join(path + "/")
+        pinned_cpus = []
+        for cpu_numbers in glob.glob(node_dir + "cpu[0-9]*"):
+            cpu = int(re.search(r".cpu(\d+)$", cpu_numbers).group(1))
+            if pinned_cpus is not None:
+                pinned_cpus.append(cpu)
+                numa_nodes_with_cpus[node] = sorted(pinned_cpus)
+    return numa_nodes_with_cpus
+
+
+def _deprecated(newfunc, oldfuncname):
+    """Print a deprecation warning and return the new function.
+
+    :param newfunc: New function to be assigned.
+    :param oldfuncname: Old function name string.
+    :return: Wrapper that warns and calls newfunc.
+    :rtype: function
+    """
+
+    def wrap(*args, **kwargs):
+        """Wrapper that emits deprecation warning and delegates to newfunc.
+
+        :param args: Positional arguments passed through to newfunc.
+        :param kwargs: Keyword arguments passed through to newfunc.
+        :return: Result of newfunc(`*args`, `**kwargs`).
+        :rtype: any
+        """
+        fmt_str = f"autils.system.cpu.{oldfuncname}() is deprecated, please use autils.system.cpu.{newfunc.__name__}() instead"
+        warnings.warn((fmt_str), DeprecationWarning, stacklevel=2)
+        return newfunc(*args, **kwargs)
+
+    return wrap
+
+
+def lscpu():
+    """Get CPU topology by executing the 'lscpu' command.
+
+    :return: Dict with keys such as 'cores_per_chip', 'physical_sockets',
+             'physical_chips', 'threads_per_core', 'sockets', 'chips',
+             'physical_cores' (depending on lscpu output).
+    :rtype: dict
+    """
+    output = process.run("LANG=en_US.UTF-8;lscpu", shell=True)
+    res = {}
+    for line in output.stdout.decode("utf-8").split("\n"):
+        if "Physical cores/chip:" in line:
+            res["cores_per_chip"] = int(line.split(":")[1].strip())
+        if "Core(s) per socket:" in line:
+            res["virtual_cores"] = int(line.split(":")[1].strip())
+        if "Physical sockets:" in line:
+            res["physical_sockets"] = int(line.split(":")[1].strip())
+        if "Physical chips:" in line:
+            res["physical_chips"] = int(line.split(":")[1].strip())
+        if "Thread(s) per core:" in line:
+            res["threads_per_core"] = int(line.split(":")[1].strip())
+        if "Socket(s):" in line:
+            res["sockets"] = int(line.split(":")[1].strip())
+    if "physical_sockets" in res and "physical_chips" in res:
+        res["chips"] = res["physical_sockets"] * res["physical_chips"]
+    if (
+        "physical_sockets" in res
+        and "physical_chips" in res
+        and "cores_per_chip" in res
+    ):
+        res["physical_cores"] = (
+            res["physical_sockets"] * res["physical_chips"] * res["cores_per_chip"]
+        )
+    return res
+
+
+total_cpus_count = _deprecated(total_count, "total_cpus_count")
+_get_cpu_info = _deprecated(_get_info, "_get_cpu_info")
+_get_cpu_status = _deprecated(_get_status, "_get_cpu_status")
+get_cpu_vendor_name = _deprecated(get_vendor, "get_cpu_vendor_name")
+get_cpu_arch = _deprecated(get_arch, "get_cpu_arch")
+cpu_online_list = _deprecated(online_list, "cpu_online_list")
+online_cpus_count = _deprecated(online_count, "online_cpus_count")
+get_cpuidle_state = _deprecated(get_idle_state, "get_cpuidle_state")
+set_cpuidle_state = _deprecated(set_idle_state, "set_cpuidle_state")
+set_cpufreq_governor = _deprecated(set_freq_governor, "set_cpufreq_governor")
+get_cpufreq_governor = _deprecated(get_freq_governor, "get_cpufreq_governor")

--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -16,6 +16,13 @@ Ports
 -----
 .. automodule:: autils.network.ports
 
+System
+======
+
+CPU
+---
+.. automodule:: autils.system.cpu
+
 
 File
 =======

--- a/metadata/system/cpu.yml
+++ b/metadata/system/cpu.yml
@@ -1,0 +1,17 @@
+name: cpu
+description: Utilities for querying and managing CPU information on the current machine
+
+categories:
+  - OS
+  - Misc
+maintainers:
+  - name: Harvey James Lynden
+    email: hlynden@redhat.com
+    github_usr_name: harvey0100
+supported_platforms:
+  - CentOS Stream 9
+  - Fedora 36
+  - Fedora 37
+tests:
+  - tests/unit/modules/system/cpu.py
+remote: false

--- a/tests/unit/modules/system/cpu.py
+++ b/tests/unit/modules/system/cpu.py
@@ -1,0 +1,501 @@
+import io
+import os
+import unittest
+import unittest.mock
+
+from autils.system import cpu
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), os.path.basename(__file__) + ".data")
+
+
+class Cpu(unittest.TestCase):
+    @staticmethod
+    def _get_file_mock(content):
+        file_mock = unittest.mock.Mock()
+        file_mock.__enter__ = unittest.mock.Mock(return_value=io.BytesIO(content))
+        file_mock.__exit__ = unittest.mock.Mock()
+        return file_mock
+
+    def _get_data_mock(self, data_name):
+        with open(os.path.join(DATA_DIR, data_name), "rb") as data_file:
+            content = data_file.read()
+        return self._get_file_mock(content)
+
+    def test_s390x_cpu_online(self):
+        with unittest.mock.patch(
+            "autils.system.cpu.platform.machine", return_value="s390x"
+        ):
+            with unittest.mock.patch(
+                "builtins.open", return_value=self._get_data_mock("s390x")
+            ):
+                self.assertEqual(len(cpu.online_list()), 2)
+            with unittest.mock.patch(
+                "builtins.open", return_value=self._get_data_mock("s390x_2")
+            ):
+                self.assertEqual(len(cpu.online_list()), 4)
+            with unittest.mock.patch(
+                "builtins.open", return_value=self._get_data_mock("s390x_3")
+            ):
+                self.assertEqual(len(cpu.online_list()), 6)
+            with unittest.mock.patch(
+                "builtins.open", return_value=self._get_data_mock("s390x_4")
+            ):
+                self.assertEqual(len(cpu.online_list()), 16)
+
+    def test_x86_64_cpu_online(self):
+        with unittest.mock.patch(
+            "autils.system.cpu.platform.machine", return_value="x86_64"
+        ):
+            with unittest.mock.patch(
+                "builtins.open", return_value=self._get_data_mock("x86_64")
+            ):
+                self.assertEqual(len(cpu.online_list()), 8)
+
+    def test_cpu_arch_i386(self):
+        with unittest.mock.patch(
+            "builtins.open", return_value=self._get_data_mock("i386")
+        ):
+            self.assertEqual(cpu.get_arch(), "i386")
+
+    def test_cpu_arch_x86_64(self):
+        with unittest.mock.patch(
+            "builtins.open", return_value=self._get_data_mock("x86_64")
+        ):
+            self.assertEqual(cpu.get_arch(), "x86_64")
+
+    def test_cpu_has_flags(self):
+        with unittest.mock.patch(
+            "builtins.open", return_value=self._get_data_mock("x86_64")
+        ):
+            self.assertTrue(cpu.cpu_has_flags("flexpriority"))
+            self.assertTrue(cpu.cpu_has_flags(["sse4_2", "xsaveopt"]))
+            self.assertFalse(cpu.cpu_has_flags("THIS_WILL_NEVER_BE_A_FLAG_NAME"))
+            self.assertFalse(
+                cpu.cpu_has_flags(
+                    ["THIS_WILL_NEVER_BE_A_FLAG_NAME", "NEITHER_WILL_THIS_WILL_EVER_BE"]
+                )
+            )
+
+    def test_cpu_arch_power8(self):
+        with unittest.mock.patch(
+            "builtins.open", return_value=self._get_data_mock("power8")
+        ):
+            self.assertEqual(cpu.get_arch(), "powerpc")
+
+    def test_cpu_arch_power9(self):
+        with unittest.mock.patch(
+            "builtins.open", return_value=self._get_data_mock("power9")
+        ):
+            self.assertEqual(cpu.get_arch(), "powerpc")
+
+    def test_cpu_arch_s390(self):
+        with unittest.mock.patch(
+            "builtins.open", return_value=self._get_data_mock("s390x")
+        ):
+            self.assertEqual(cpu.get_arch(), "s390")
+
+    def test_cpu_arch_arm_v7(self):
+        with unittest.mock.patch(
+            "builtins.open", return_value=self._get_data_mock("armv7")
+        ):
+            self.assertEqual(cpu.get_arch(), "arm")
+
+    def test_cpu_arch_arm_v8(self):
+        with unittest.mock.patch(
+            "builtins.open", return_value=self._get_data_mock("armv8")
+        ):
+            self.assertEqual(cpu.get_arch(), "aarch64")
+
+    def test_cpu_arch_risc_v(self):
+        with unittest.mock.patch(
+            "builtins.open", return_value=self._get_data_mock("risc_v")
+        ):
+            self.assertEqual(cpu.get_arch(), "riscv")
+
+    def test_cpu_vendor_intel(self):
+        with unittest.mock.patch(
+            "builtins.open", return_value=self._get_data_mock("x86_64")
+        ):
+            self.assertEqual(cpu.get_vendor(), "intel")
+
+    def test_cpu_vendor_power8(self):
+        with unittest.mock.patch(
+            "builtins.open", return_value=self._get_data_mock("power8")
+        ):
+            self.assertEqual(cpu.get_vendor(), "ibm")
+
+    def test_cpu_vendor_power9(self):
+        with unittest.mock.patch(
+            "builtins.open", return_value=self._get_data_mock("power9")
+        ):
+            self.assertEqual(cpu.get_vendor(), "ibm")
+
+    def test_get_vendor_none(self):
+        """Test get_vendor returns None when cpuinfo matches no known vendor."""
+        cpuinfo = b"processor : 0\ncpu : Unknown\n"
+        with unittest.mock.patch(
+            "builtins.open", return_value=self._get_file_mock(cpuinfo)
+        ):
+            self.assertIsNone(cpu.get_vendor())
+
+    def test_s390x_get_version(self):
+        with unittest.mock.patch(
+            "autils.system.cpu.platform.machine", return_value="s390x"
+        ):
+            with unittest.mock.patch(
+                "builtins.open", return_value=self._get_data_mock("s390x")
+            ):
+                self.assertEqual(cpu.get_version(), "2827")
+
+    def test_intel_get_version(self):
+        with unittest.mock.patch(
+            "autils.system.cpu.platform.machine", return_value="x86_64"
+        ):
+            with unittest.mock.patch(
+                "builtins.open", return_value=self._get_data_mock("x86_64")
+            ):
+                self.assertEqual(cpu.get_version(), "i7-4710MQ")
+
+    def test_get_version_unsupported_arch(self):
+        """Test get_version returns empty string when arch has no version pattern."""
+        with unittest.mock.patch(
+            "builtins.open", return_value=self._get_data_mock("risc_v")
+        ):
+            self.assertEqual(cpu.get_version(), "")
+
+    def test_power8_get_version(self):
+        with unittest.mock.patch(
+            "autils.system.cpu.platform.machine", return_value="powerpc"
+        ):
+            with unittest.mock.patch(
+                "builtins.open", return_value=self._get_data_mock("power8")
+            ):
+                self.assertEqual(cpu.get_version(), "2.1")
+
+    def test_power9_get_version(self):
+        with unittest.mock.patch(
+            "autils.system.cpu.platform.machine", return_value="powerpc"
+        ):
+            with unittest.mock.patch(
+                "builtins.open", return_value=self._get_data_mock("power9")
+            ):
+                self.assertEqual(cpu.get_version(), "1.0")
+
+    def test_s390x_get_family(self):
+        with unittest.mock.patch("autils.system.cpu.get_arch", return_value="s390"):
+            with unittest.mock.patch(
+                "autils.system.cpu.get_version", return_value="8561"
+            ):
+                self.assertEqual(cpu.get_family(), "z15")
+
+    def test_intel_get_family(self):
+        with unittest.mock.patch("autils.system.cpu.get_arch", return_value="x86_64"):
+            with unittest.mock.patch(
+                "autils.system.cpu.get_vendor", return_value="intel"
+            ):
+                with unittest.mock.patch(
+                    "builtins.open", return_value=self._get_file_mock(b"broadwell")
+                ):
+                    self.assertEqual(cpu.get_family(), "broadwell")
+
+    def test_get_family_intel_file_not_found(self):
+        """Test get_family raises FamilyException when pmu_name missing (Intel)."""
+        with unittest.mock.patch("autils.system.cpu.get_arch", return_value="x86_64"):
+            with unittest.mock.patch(
+                "autils.system.cpu.get_vendor", return_value="intel"
+            ):
+                with unittest.mock.patch(
+                    "builtins.open", side_effect=FileNotFoundError("No such file")
+                ):
+                    with self.assertRaises(cpu.FamilyException):
+                        cpu.get_family()
+
+    def test_get_family_not_implemented(self):
+        """Test get_family raises NotImplementedError for unsupported arch."""
+        with unittest.mock.patch("autils.system.cpu.get_arch", return_value="aarch64"):
+            with self.assertRaises(NotImplementedError):
+                cpu.get_family()
+
+    def test_power8_get_family(self):
+        with unittest.mock.patch("autils.system.cpu.get_arch", return_value="powerpc"):
+            with unittest.mock.patch(
+                "builtins.open", return_value=self._get_data_mock("power8")
+            ):
+                self.assertEqual(cpu.get_family(), "power8")
+
+    def test_power9_get_family(self):
+        with unittest.mock.patch("autils.system.cpu.get_arch", return_value="powerpc"):
+            with unittest.mock.patch(
+                "builtins.open", return_value=self._get_data_mock("power9")
+            ):
+                self.assertEqual(cpu.get_family(), "power9")
+
+    def test_get_idle_state_off(self):
+        retval = {0: {0: False}}
+        with unittest.mock.patch("autils.system.cpu.online_list", return_value=[0]):
+            with unittest.mock.patch(
+                "glob.glob",
+                return_value=["/sys/devices/system/cpu/cpu0/cpuidle/state1"],
+            ):
+                mocked_open = unittest.mock.mock_open(read_data=b"0")
+                with unittest.mock.patch("builtins.open", mocked_open):
+                    self.assertEqual(cpu.get_idle_state(), retval)
+
+    def test_get_idle_state_io_error(self):
+        """Test get_idle_state handles IOError when reading state file."""
+        with unittest.mock.patch("autils.system.cpu.online_list", return_value=[0]):
+            with unittest.mock.patch(
+                "glob.glob",
+                return_value=["/sys/devices/system/cpu/cpu0/cpuidle/state1"],
+            ):
+                with unittest.mock.patch(
+                    "builtins.open", side_effect=IOError("Permission denied")
+                ):
+                    result = cpu.get_idle_state()
+                    self.assertEqual(result, {0: {}})
+
+    def test_get_idle_state_on(self):
+        retval = {0: {0: True}}
+        with unittest.mock.patch("autils.system.cpu.online_list", return_value=[0]):
+            with unittest.mock.patch(
+                "glob.glob",
+                return_value=["/sys/devices/system/cpu/cpu0/cpuidle/state1"],
+            ):
+                mocked_open = unittest.mock.mock_open(read_data=b"1")
+                with unittest.mock.patch("builtins.open", mocked_open):
+                    self.assertEqual(cpu.get_idle_state(), retval)
+
+    def test_set_idle_state_default(self):
+        with unittest.mock.patch("autils.system.cpu.online_list", return_value=[0]):
+            with unittest.mock.patch(
+                "glob.glob",
+                return_value=["/sys/devices/system/cpu/cpu0/cpuidle/state1"],
+            ):
+                mocked_open = unittest.mock.mock_open()
+                with unittest.mock.patch("builtins.open", mocked_open):
+                    cpu.set_idle_state()
+                mocked_open.assert_called_with(
+                    "/sys/devices/system/cpu/cpu0/cpuidle/state0/disable", "wb"
+                )
+                mocked_fo = mocked_open()
+                mocked_fo.write.assert_called_once_with(b"1")
+
+    def test_set_idle_state_withstateno(self):
+        with unittest.mock.patch("autils.system.cpu.online_list", return_value=[0]):
+            with unittest.mock.patch(
+                "glob.glob",
+                return_value=["/sys/devices/system/cpu/cpu0/cpuidle/state2"],
+            ):
+                mocked_open = unittest.mock.mock_open()
+                with unittest.mock.patch("builtins.open", mocked_open):
+                    cpu.set_idle_state(disable=False, state_number="2")
+                mocked_open.assert_called_with(
+                    "/sys/devices/system/cpu/cpu0/cpuidle/state2/disable", "wb"
+                )
+                mocked_fo = mocked_open()
+                mocked_fo.write.assert_called_once_with(b"0")
+
+    def test_set_idle_state_withsetstate(self):
+        with unittest.mock.patch("autils.system.cpu.online_list", return_value=[0, 2]):
+            with unittest.mock.patch(
+                "glob.glob",
+                return_value=["/sys/devices/system/cpu/cpu0/cpuidle/state1"],
+            ):
+                mocked_open = unittest.mock.mock_open()
+                with unittest.mock.patch("builtins.open", mocked_open):
+                    cpu.set_idle_state(setstate={0: {0: True}, 2: {0: False}})
+                mocked_open.assert_called_with(
+                    "/sys/devices/system/cpu/cpu2/cpuidle/state0/disable", "wb"
+                )
+                mocked_fo = mocked_open()
+                mocked_fo.write.assert_called_with(b"0")
+
+    def test_set_idle_state_disable(self):
+        function = "autils.system.cpu.online_list"
+        state_file = "/sys/devices/system/cpu/cpu0/cpuidle/state1"
+        with unittest.mock.patch(function, return_value=[0, 2]):
+            with unittest.mock.patch("glob.glob", return_value=[state_file]):
+                mocked_open = unittest.mock.mock_open()
+                with unittest.mock.patch("builtins.open", mocked_open):
+                    with self.assertRaises(TypeError):
+                        cpu.set_idle_state(disable=1)
+
+    def test_set_idle_state_io_error(self):
+        """Test set_idle_state handles IOError when writing state file."""
+        with unittest.mock.patch("autils.system.cpu.online_list", return_value=[0]):
+            with unittest.mock.patch(
+                "glob.glob",
+                return_value=["/sys/devices/system/cpu/cpu0/cpuidle/state1"],
+            ):
+                with unittest.mock.patch(
+                    "builtins.open", side_effect=IOError("Permission denied")
+                ):
+                    cpu.set_idle_state()
+
+    def test_get_revision(self):
+        """Test get_revision parses revision from cpuinfo."""
+        cpuinfo = "processor : 0\nrevision  : 0080\n"
+        with unittest.mock.patch(
+            "autils.system.cpu.genio.read_file", return_value=cpuinfo
+        ):
+            self.assertEqual(cpu.get_revision(), "0080")
+
+    def test_get_revision_no_revision(self):
+        """Test get_revision returns None when no revision line."""
+        with unittest.mock.patch(
+            "autils.system.cpu.genio.read_file", return_value="processor : 0\n"
+        ):
+            self.assertIsNone(cpu.get_revision())
+
+    def test_get_va_bits(self):
+        """Test get_va_bits extracts VA bits from address sizes line."""
+        cpuinfo = "address sizes : 39 bits physical, 48 bits virtual\n"
+        with unittest.mock.patch(
+            "autils.system.cpu.genio.read_file", return_value=cpuinfo
+        ):
+            self.assertEqual(cpu.get_va_bits(), "48")
+
+    def test_get_va_bits_empty(self):
+        """Test get_va_bits returns empty string when no address sizes."""
+        with unittest.mock.patch(
+            "autils.system.cpu.genio.read_file", return_value="processor : 0\n"
+        ):
+            self.assertEqual(cpu.get_va_bits(), "")
+
+    def test_get_model_x86_64(self):
+        """Test get_model extracts model for x86_64."""
+        with unittest.mock.patch("autils.system.cpu.get_arch", return_value="x86_64"):
+            with unittest.mock.patch(
+                "builtins.open", return_value=self._get_data_mock("x86_64")
+            ):
+                result = cpu.get_model()
+                self.assertIsInstance(result, int)
+                self.assertGreaterEqual(result, 0)
+
+    def test_get_model_not_implemented(self):
+        """Test get_model raises NotImplementedError for non-x86_64."""
+        with unittest.mock.patch("autils.system.cpu.get_arch", return_value="powerpc"):
+            with self.assertRaises(NotImplementedError):
+                cpu.get_model()
+
+    def test_get_model_no_model_line(self):
+        """Test get_model returns None when cpuinfo has no model line."""
+        cpuinfo = b"processor : 0\nvendor_id : GenuineIntel\n"
+        with unittest.mock.patch("autils.system.cpu.get_arch", return_value="x86_64"):
+            with unittest.mock.patch(
+                "builtins.open", return_value=self._get_file_mock(cpuinfo)
+            ):
+                self.assertIsNone(cpu.get_model())
+
+    def test_get_x86_amd_zen_with_params(self):
+        """Test get_x86_amd_zen with explicit family/model."""
+        self.assertEqual(cpu.get_x86_amd_zen(family=23, model=0), 1)
+        self.assertEqual(cpu.get_x86_amd_zen(family=23, model=0x30), 2)
+        self.assertEqual(cpu.get_x86_amd_zen(family=25, model=0), 3)
+        self.assertIsNone(cpu.get_x86_amd_zen(family=0x99, model=0))
+
+    def test_get_x86_amd_zen_family_match_model_no_match(self):
+        """Test get_x86_amd_zen returns None when family matches but model outside ranges."""
+        # Family 0x17 (Zen) but model 0x80 is in gap between Zen 1/2 ranges
+        self.assertIsNone(cpu.get_x86_amd_zen(family=23, model=0x80))
+
+    def test_total_count(self):
+        """Test total_count returns sysconf value."""
+        with unittest.mock.patch("os.sysconf", return_value=8):
+            self.assertEqual(cpu.total_count(), 8)
+
+    def test_deprecated_alias(self):
+        """Test deprecated total_cpus_count alias calls total_count."""
+        with unittest.mock.patch("os.sysconf", return_value=8):
+            with self.assertWarns(DeprecationWarning):
+                self.assertEqual(cpu.total_cpus_count(), 8)
+
+    def test_online_count(self):
+        """Test online_count returns sysconf value."""
+        with unittest.mock.patch("os.sysconf", return_value=8):
+            self.assertEqual(cpu.online_count(), 8)
+
+    def test_is_hotpluggable_true(self):
+        """Test is_hotpluggable when cpu online file exists."""
+        with unittest.mock.patch("os.path.exists", return_value=True):
+            self.assertTrue(cpu.is_hotpluggable(1))
+
+    def test_is_hotpluggable_false(self):
+        """Test is_hotpluggable when cpu online file does not exist."""
+        with unittest.mock.patch("os.path.exists", return_value=False):
+            self.assertFalse(cpu.is_hotpluggable(0))
+
+    def test_online_already_online(self):
+        """Test online returns 1 when CPU is already online."""
+        with unittest.mock.patch("autils.system.cpu._get_status", return_value=True):
+            self.assertEqual(cpu.online(1), 1)
+
+    def test_online_cpu_failure(self):
+        """Test online returns 0 when write to sysfs does not persist."""
+        with unittest.mock.patch(
+            "autils.system.cpu._get_status", side_effect=[False, False]
+        ):
+            with unittest.mock.patch("builtins.open", unittest.mock.mock_open()):
+                self.assertEqual(cpu.online(1), 0)
+
+    def test_offline_already_offline(self):
+        """Test offline returns 0 when CPU is already offline."""
+        with unittest.mock.patch("autils.system.cpu._get_status", return_value=False):
+            self.assertEqual(cpu.offline(1), 0)
+
+    def test_offline_cpu_failure(self):
+        """Test offline returns 1 when write to sysfs does not persist."""
+        with unittest.mock.patch(
+            "autils.system.cpu._get_status", side_effect=[True, True]
+        ):
+            with unittest.mock.patch("builtins.open", unittest.mock.mock_open()):
+                self.assertEqual(cpu.offline(1), 1)
+
+    def test_get_freq_governor(self):
+        """Test get_freq_governor reads scaling_governor."""
+        with unittest.mock.patch(
+            "builtins.open",
+            unittest.mock.mock_open(read_data="performance"),
+        ):
+            self.assertEqual(cpu.get_freq_governor(), "performance")
+
+    def test_get_freq_governor_io_error(self):
+        """Test get_freq_governor returns empty on IOError."""
+        with unittest.mock.patch("builtins.open", side_effect=IOError("No such file")):
+            self.assertEqual(cpu.get_freq_governor(), "")
+
+    def test_set_freq_governor_no_current(self):
+        """Test set_freq_governor returns False when get_freq_governor is empty."""
+        with unittest.mock.patch(
+            "autils.system.cpu.get_freq_governor", return_value=""
+        ):
+            self.assertFalse(cpu.set_freq_governor("performance"))
+
+    def test_get_numa_node_has_cpus(self):
+        """Test get_numa_node_has_cpus parses has_cpu file."""
+        with unittest.mock.patch(
+            "autils.system.cpu.genio.read_file", return_value="0-3\n"
+        ):
+            self.assertEqual(cpu.get_numa_node_has_cpus(), ["0", "3"])
+
+    def test_lscpu(self):
+        """Test lscpu parses output."""
+        output = unittest.mock.Mock()
+        output.stdout = (
+            b"Core(s) per socket: 4\n"
+            b"Thread(s) per core: 2\n"
+            b"Socket(s): 2\n"
+            b"Physical cores/chip: 4\n"
+            b"Physical sockets: 2\n"
+            b"Physical chips: 2\n"
+        )
+        with unittest.mock.patch("autils.system.cpu.process.run", return_value=output):
+            result = cpu.lscpu()
+            self.assertEqual(result["virtual_cores"], 4)
+            self.assertEqual(result["threads_per_core"], 2)
+            self.assertEqual(result["sockets"], 2)
+            self.assertEqual(result["chips"], 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/modules/system/cpu.py.data/armv7
+++ b/tests/unit/modules/system/cpu.py.data/armv7
@@ -1,0 +1,12 @@
+Processor       : ARMv7 Processor rev 2 (v7l)
+BogoMIPS        : 994.65
+Features        : swp half thumb fastmult vfp edsp thumbee neon vfpv3
+CPU implementer : 0x41
+CPU architecture: 7
+CPU variant     : 0x2
+CPU part        : 0xc08
+CPU revision    : 2
+
+Hardware        : herring
+Revision        : 0034
+Serial          : 3534268a5e0700ec

--- a/tests/unit/modules/system/cpu.py.data/armv8
+++ b/tests/unit/modules/system/cpu.py.data/armv8
@@ -1,0 +1,8 @@
+processor       : 0
+BogoMIPS        : 200.00
+Features        : fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
+CPU implementer : 0x43
+CPU architecture: 8
+CPU variant     : 0x1
+CPU part        : 0x0a1
+CPU revision    : 1

--- a/tests/unit/modules/system/cpu.py.data/i386
+++ b/tests/unit/modules/system/cpu.py.data/i386
@@ -1,0 +1,29 @@
+processor       : 0
+vendor_id       : GenuineIntel
+cpu family      : 6
+model           : 13
+model name      : Intel(R) Pentium(R) M processor 2.00GHz
+stepping        : 8
+microcode       : 0x20
+cpu MHz         : 2000.000
+cache size      : 2048 KB
+physical id     : 0
+siblings        : 1
+core id         : 0
+cpu cores       : 1
+apicid          : 0
+initial apicid  : 0
+fdiv_bug        : no
+f00f_bug        : no
+coma_bug        : no
+fpu             : yes
+fpu_exception   : yes
+cpuid level     : 2
+wp              : yes
+flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov clflush dts acpi mmx fxsr sse sse2 ss tm pbe nx bts cpuid est tm2
+bugs            : cpu_meltdown spectre_v1 spectre_v2
+bogomips        : 3990.09
+clflush size    : 64
+cache_alignment : 64
+address sizes   : 32 bits physical, 32 bits virtual
+power management:

--- a/tests/unit/modules/system/cpu.py.data/power8
+++ b/tests/unit/modules/system/cpu.py.data/power8
@@ -1,0 +1,10 @@
+processor       : 88
+cpu             : POWER8E (raw), altivec supported
+clock           : 3325.000000MHz
+revision        : 2.1 (pvr 004b 0201)
+
+timebase        : 512000000
+platform        : PowerNV
+model           : 8247-21L
+machine         : PowerNV 8247-21L
+firmware        : OPAL v3

--- a/tests/unit/modules/system/cpu.py.data/power9
+++ b/tests/unit/modules/system/cpu.py.data/power9
@@ -1,0 +1,10 @@
+processor    : 20
+cpu        : POWER9 (raw), altivec supported
+clock        : 2050.000000MHz
+revision    : 1.0 (pvr 004e 0100)
+
+timebase    : 512000000
+platform    : PowerNV
+model        : 8375-42A
+machine        : PowerNV 8375-42A
+firmware    : OPAL

--- a/tests/unit/modules/system/cpu.py.data/risc_v
+++ b/tests/unit/modules/system/cpu.py.data/risc_v
@@ -1,0 +1,4 @@
+hart    : 1
+isa    : rv64imafdc
+mmu    : sv39
+uarch    : sifive,rocket0

--- a/tests/unit/modules/system/cpu.py.data/s390x
+++ b/tests/unit/modules/system/cpu.py.data/s390x
@@ -1,0 +1,22 @@
+vendor_id       : IBM/S390
+# processors    : 2
+bogomips per cpu: 2913.00
+max thread id   : 0
+features        : esan3 zarch stfle msa ldisp eimm dfp edat etf3eh highgprs te sie
+facilities      : 0 1 2 3 4 6 7 8 9 10 12 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 30 31 32 33 34 35 36 37 40 41 42 43 44 45 46 47 48 49 50 51 52 57 73 74 75 76 77
+cache0          : level=1 type=Data scope=Private size=96K line_size=256 associativity=6
+cache1          : level=1 type=Instruction scope=Private size=64K line_size=256 associativity=4
+cache2          : level=2 type=Data scope=Private size=1024K line_size=256 associativity=8
+cache3          : level=2 type=Instruction scope=Private size=1024K line_size=256 associativity=8
+cache4          : level=3 type=Unified scope=Shared size=49152K line_size=256 associativity=12
+cache5          : level=4 type=Unified scope=Shared size=393216K line_size=256 associativity=24
+processor 0: version = FF,  identification = 32C047,  machine = 2827
+processor 1: version = FF,  identification = 32C047,  machine = 2827
+
+cpu number      : 0
+cpu MHz dynamic : 5504
+cpu MHz static  : 5504
+
+cpu number      : 1
+cpu MHz dynamic : 5504
+cpu MHz static  : 5504

--- a/tests/unit/modules/system/cpu.py.data/s390x_2
+++ b/tests/unit/modules/system/cpu.py.data/s390x_2
@@ -1,0 +1,32 @@
+vendor_id       : IBM/S390
+# processors    : 4
+bogomips per cpu: 2913.00
+max thread id   : 0
+features        : esan3 zarch stfle msa ldisp eimm dfp edat etf3eh highgprs te sie
+facilities      : 0 1 2 3 4 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 30 31 32 33 34 35 36 37 40 41 42 43 44 45 46 47 48 49 50 51 52 57 64 65 66 67 68 69 70 71 72 73 75 76 77 78 131 132
+cache0          : level=1 type=Data scope=Private size=96K line_size=256 associativity=6
+cache1          : level=1 type=Instruction scope=Private size=64K line_size=256 associativity=4
+cache2          : level=2 type=Data scope=Private size=1024K line_size=256 associativity=8
+cache3          : level=2 type=Instruction scope=Private size=1024K line_size=256 associativity=8
+cache4          : level=3 type=Unified scope=Shared size=49152K line_size=256 associativity=12
+cache5          : level=4 type=Unified scope=Shared size=393216K line_size=256 associativity=24
+processor 0: version = 00,  identification = 3FC047,  machine = 2827
+processor 1: version = 00,  identification = 3FC047,  machine = 2827
+processor 2: version = 00,  identification = 3FC047,  machine = 2827
+processor 3: version = 00,  identification = 3FC047,  machine = 2827
+
+cpu number      : 0
+cpu MHz dynamic : 5504
+cpu MHz static  : 5504
+
+cpu number      : 1
+cpu MHz dynamic : 5504
+cpu MHz static  : 5504
+
+cpu number      : 2
+cpu MHz dynamic : 5504
+cpu MHz static  : 5504
+
+cpu number      : 3
+cpu MHz dynamic : 5504
+cpu MHz static  : 5504

--- a/tests/unit/modules/system/cpu.py.data/s390x_3
+++ b/tests/unit/modules/system/cpu.py.data/s390x_3
@@ -1,0 +1,54 @@
+vendor_id       : IBM/S390
+# processors    : 24
+bogomips per cpu: 24038.00
+max thread id   : 1
+features    : esan3 zarch stfle msa ldisp eimm dfp edat etf3eh highgprs te vx vxd vxe gs sie
+facilities      : 0 1 2 3 4 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 30 31 32 33 34 35 36 37 38 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 57 58 59 60 61 64 65 66 67 68 69 70 71 72 73 75 76 77 78 80 81 82 128 129 130 131 132 133 134 135 138 139 141 142 144 145 146 148 149 150 151 152 155 156
+cache0          : level=1 type=Data scope=Private size=128K line_size=256 associativity=8
+cache1          : level=1 type=Instruction scope=Private size=128K line_size=256 associativity=8
+cache2          : level=2 type=Data scope=Private size=4096K line_size=256 associativity=8
+cache3          : level=2 type=Instruction scope=Private size=4096K line_size=256 associativity=8
+cache4          : level=3 type=Unified scope=Shared size=262144K line_size=256 associativity=32
+cache5          : level=4 type=Unified scope=Shared size=983040K line_size=256 associativity=60
+processor 0: version = 00,  identification = 2A66A8,  machine = 8561
+processor 1: version = 00,  identification = 2A66A8,  machine = 8561
+processor 2: version = 00,  identification = 2A66A8,  machine = 8561
+processor 3: version = 00,  identification = 2A66A8,  machine = 8561
+processor 4: version = 00,  identification = 2A66A8,  machine = 8561
+processor 5: version = 00,  identification = 2A66A8,  machine = 8561
+processor 6: version = 00,  identification = 2A66A8,  machine = 8561
+processor 7: version = 00,  identification = 2A66A8,  machine = 8561
+processor 8: version = 00,  identification = 2A66A8,  machine = 8561
+processor 9: version = 00,  identification = 2A66A8,  machine = 8561
+processor 10: version = 00,  identification = 2A66A8,  machine = 8561
+processor 11: version = 00,  identification = 2A66A8,  machine = 8561
+processor 12: version = 00,  identification = 2A66A8,  machine = 8561
+processor 13: version = 00,  identification = 2A66A8,  machine = 8561
+processor 14: version = 00,  identification = 2A66A8,  machine = 8561
+processor 15: version = 00,  identification = 2A66A8,  machine = 8561
+processor 16: version = 00,  identification = 2A66A8,  machine = 8561
+processor 17: version = 00,  identification = 2A66A8,  machine = 8561
+processor 18: version = 00,  identification = 2A66A8,  machine = 8561
+processor 19: version = 00,  identification = 2A66A8,  machine = 8561
+processor 20: version = 00,  identification = 2A66A8,  machine = 8561
+processor 21: version = 00,  identification = 2A66A8,  machine = 8561
+processor 22: version = 00,  identification = 2A66A8,  machine = 8561
+processor 23: version = 00,  identification = 2A66A8,  machine = 8561
+cpu number      : 0
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+cpu number      : 1
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+cpu number      : 2
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+cpu number      : 3
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+cpu number      : 4
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+cpu number      : 5
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200

--- a/tests/unit/modules/system/cpu.py.data/s390x_4
+++ b/tests/unit/modules/system/cpu.py.data/s390x_4
@@ -1,0 +1,90 @@
+vendor_id       : IBM/S390
+# processors    : 16
+bogomips per cpu: 3331.00
+max thread id   : 1
+features	: esan3 zarch stfle msa ldisp eimm dfp edat etf3eh highgprs te vx vxd vxe gs vxe2 vxp sort dflt vxp2 nnpa pcimio sie
+facilities      : 0 1 2 3 4 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 30 31 32 33 34 35 36 37 38 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 57 58 59 60 61 64 65 66 67 68 69 70 71 72 73 75 76 77 78 80 81 82 129 130 131 132 133 134 135 138 139 141 142 144 145 146 148 149 150 151 152 153 155 156 158 165 192 193 194 196 197
+cache0          : level=1 type=Data scope=Private size=128K line_size=256 associativity=8
+cache1          : level=1 type=Instruction scope=Private size=128K line_size=256 associativity=8
+cache2          : level=2 type=Unified scope=Private size=32768K line_size=256 associativity=16
+cache3          : level=3 type=Unified scope=Shared size=262144K line_size=256 associativity=128
+processor 0: version = 00,  identification = 285FA8,  machine = 3931
+processor 1: version = 00,  identification = 285FA8,  machine = 3931
+processor 2: version = 00,  identification = 285FA8,  machine = 3931
+processor 3: version = 00,  identification = 285FA8,  machine = 3931
+processor 4: version = 00,  identification = 285FA8,  machine = 3931
+processor 5: version = 00,  identification = 285FA8,  machine = 3931
+processor 6: version = 00,  identification = 285FA8,  machine = 3931
+processor 7: version = 00,  identification = 285FA8,  machine = 3931
+processor 8: version = 00,  identification = 285FA8,  machine = 3931
+processor 9: version = 00,  identification = 285FA8,  machine = 3931
+processor 10: version = 00,  identification = 285FA8,  machine = 3931
+processor 11: version = 00,  identification = 285FA8,  machine = 3931
+processor 12: version = 00,  identification = 285FA8,  machine = 3931
+processor 13: version = 00,  identification = 285FA8,  machine = 3931
+processor 14: version = 00,  identification = 285FA8,  machine = 3931
+processor 15: version = 00,  identification = 285FA8,  machine = 3931
+
+cpu number      : 0
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+
+cpu number      : 1
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+
+cpu number      : 2
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+
+cpu number      : 3
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+
+cpu number      : 4
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+
+cpu number      : 5
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+
+cpu number      : 6
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+
+cpu number      : 7
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+
+cpu number      : 8
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+
+cpu number      : 9
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+
+cpu number      : 10
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+
+cpu number      : 11
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+
+cpu number      : 12
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+
+cpu number      : 13
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+
+cpu number      : 14
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+
+cpu number      : 15
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200

--- a/tests/unit/modules/system/cpu.py.data/x86_64
+++ b/tests/unit/modules/system/cpu.py.data/x86_64
@@ -1,0 +1,215 @@
+processor    : 0
+vendor_id    : GenuineIntel
+cpu family    : 6
+model        : 60
+model name    : Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz
+stepping    : 3
+microcode    : 0x22
+cpu MHz        : 2494.301
+cache size    : 6144 KB
+physical id    : 0
+siblings    : 8
+core id        : 0
+cpu cores    : 4
+apicid        : 0
+initial apicid    : 0
+fpu        : yes
+fpu_exception    : yes
+cpuid level    : 13
+wp        : yes
+flags        : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt dtherm ida arat pln pts
+bugs        :
+bogomips    : 4988.60
+clflush size    : 64
+cache_alignment    : 64
+address sizes    : 39 bits physical, 48 bits virtual
+power management:
+
+processor    : 1
+vendor_id    : GenuineIntel
+cpu family    : 6
+model        : 60
+model name    : Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz
+stepping    : 3
+microcode    : 0x22
+cpu MHz        : 2494.301
+cache size    : 6144 KB
+physical id    : 0
+siblings    : 8
+core id        : 0
+cpu cores    : 4
+apicid        : 1
+initial apicid    : 1
+fpu        : yes
+fpu_exception    : yes
+cpuid level    : 13
+wp        : yes
+flags        : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt dtherm ida arat pln pts
+bugs        :
+bogomips    : 4988.60
+clflush size    : 64
+cache_alignment    : 64
+address sizes    : 39 bits physical, 48 bits virtual
+power management:
+
+processor    : 2
+vendor_id    : GenuineIntel
+cpu family    : 6
+model        : 60
+model name    : Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz
+stepping    : 3
+microcode    : 0x22
+cpu MHz        : 2494.301
+cache size    : 6144 KB
+physical id    : 0
+siblings    : 8
+core id        : 1
+cpu cores    : 4
+apicid        : 2
+initial apicid    : 2
+fpu        : yes
+fpu_exception    : yes
+cpuid level    : 13
+wp        : yes
+flags        : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt dtherm ida arat pln pts
+bugs        :
+bogomips    : 4988.60
+clflush size    : 64
+cache_alignment    : 64
+address sizes    : 39 bits physical, 48 bits virtual
+power management:
+
+processor    : 3
+vendor_id    : GenuineIntel
+cpu family    : 6
+model        : 60
+model name    : Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz
+stepping    : 3
+microcode    : 0x22
+cpu MHz        : 2494.301
+cache size    : 6144 KB
+physical id    : 0
+siblings    : 8
+core id        : 1
+cpu cores    : 4
+apicid        : 3
+initial apicid    : 3
+fpu        : yes
+fpu_exception    : yes
+cpuid level    : 13
+wp        : yes
+flags        : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt dtherm ida arat pln pts
+bugs        :
+bogomips    : 4988.60
+clflush size    : 64
+cache_alignment    : 64
+address sizes    : 39 bits physical, 48 bits virtual
+power management:
+
+processor    : 4
+vendor_id    : GenuineIntel
+cpu family    : 6
+model        : 60
+model name    : Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz
+stepping    : 3
+microcode    : 0x22
+cpu MHz        : 2494.301
+cache size    : 6144 KB
+physical id    : 0
+siblings    : 8
+core id        : 2
+cpu cores    : 4
+apicid        : 4
+initial apicid    : 4
+fpu        : yes
+fpu_exception    : yes
+cpuid level    : 13
+wp        : yes
+flags        : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt dtherm ida arat pln pts
+bugs        :
+bogomips    : 4988.60
+clflush size    : 64
+cache_alignment    : 64
+address sizes    : 39 bits physical, 48 bits virtual
+power management:
+
+processor    : 5
+vendor_id    : GenuineIntel
+cpu family    : 6
+model        : 60
+model name    : Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz
+stepping    : 3
+microcode    : 0x22
+cpu MHz        : 2494.301
+cache size    : 6144 KB
+physical id    : 0
+siblings    : 8
+core id        : 2
+cpu cores    : 4
+apicid        : 5
+initial apicid    : 5
+fpu        : yes
+fpu_exception    : yes
+cpuid level    : 13
+wp        : yes
+flags        : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt dtherm ida arat pln pts
+bugs        :
+bogomips    : 4988.60
+clflush size    : 64
+cache_alignment    : 64
+address sizes    : 39 bits physical, 48 bits virtual
+power management:
+
+processor    : 6
+vendor_id    : GenuineIntel
+cpu family    : 6
+model        : 60
+model name    : Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz
+stepping    : 3
+microcode    : 0x22
+cpu MHz        : 2494.301
+cache size    : 6144 KB
+physical id    : 0
+siblings    : 8
+core id        : 3
+cpu cores    : 4
+apicid        : 6
+initial apicid    : 6
+fpu        : yes
+fpu_exception    : yes
+cpuid level    : 13
+wp        : yes
+flags        : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt dtherm ida arat pln pts
+bugs        :
+bogomips    : 4988.60
+clflush size    : 64
+cache_alignment    : 64
+address sizes    : 39 bits physical, 48 bits virtual
+power management:
+
+processor    : 7
+vendor_id    : GenuineIntel
+cpu family    : 6
+model        : 60
+model name    : Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz
+stepping    : 3
+microcode    : 0x22
+cpu MHz        : 2494.301
+cache size    : 6144 KB
+physical id    : 0
+siblings    : 8
+core id        : 3
+cpu cores    : 4
+apicid        : 7
+initial apicid    : 7
+fpu        : yes
+fpu_exception    : yes
+cpuid level    : 13
+wp        : yes
+flags        : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt dtherm ida arat pln pts
+bugs        :
+bogomips    : 4988.60
+clflush size    : 64
+cache_alignment    : 64
+address sizes    : 39 bits physical, 48 bits virtual
+power management:


### PR DESCRIPTION
- Add autils/system/cpu.py (line-for-line from avocado)
- Add unit tests with architecture-specific cpuinfo fixtures
- Add metadata/system/cpu.yml
- Add cpu to docs under System section